### PR TITLE
ui-manchette: improves code readability

### DIFF
--- a/ui-manchette/src/components/OperationalPoint.tsx
+++ b/ui-manchette/src/components/OperationalPoint.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
-import { OperationalPointType } from '../types';
+import { StyledOperationalPointType } from '../types';
 import '@osrd-project/ui-core/dist/theme.css';
 import { positionMmToKm } from './helpers';
 
-const OperationalPoint: React.FC<OperationalPointType> = ({ extensions, id, position }) => {
+const OperationalPoint: React.FC<StyledOperationalPointType> = ({
+  extensions,
+  id,
+  position,
+  display,
+}) => {
+  if (!display) return null;
+
   return (
     <div className="flex op items-baseline" id={id}>
       <div className="op-position justify-self-start text-end">{positionMmToKm(position)}</div>

--- a/ui-manchette/src/components/consts.ts
+++ b/ui-manchette/src/components/consts.ts
@@ -2,3 +2,11 @@ export const BASE_OP_HEIGHT = 32;
 export const BASE_KM_HEIGHT = 8;
 export const INITIAL_OP_LIST_HEIGHT = 521;
 export const INITIAL_SPACE_TIME_CHART_HEIGHT = INITIAL_OP_LIST_HEIGHT + 40;
+
+export const MIN_ZOOM_X = 1;
+export const MAX_ZOOM_X = 1;
+export const ZOOM_X_DELTA = 0.5;
+
+export const MIN_ZOOM_Y = 1;
+export const MAX_ZOOM_Y = 10.5;
+export const ZOOM_Y_DELTA = 0.5;

--- a/ui-manchette/src/types.ts
+++ b/ui-manchette/src/types.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { type CSSProperties } from 'react';
 
 export type PathProperties = {
   electrifications?: {
@@ -84,7 +84,7 @@ export type ArrayElement<ArrayType extends readonly unknown[] | null | undefined
 export type OperationalPointType = ArrayElement<PathProperties['operational_points'] | null>;
 
 export type StyledOperationalPointType = OperationalPointType & {
-  styles?: React.CSSProperties;
+  styles?: CSSProperties;
   display?: boolean;
 };
 
@@ -114,7 +114,6 @@ export type ProjectPathTrainResult = {
     positions: number[];
     times: number[];
   }[];
-} & {
   /** Departure time of the train */
   departure_time: string;
   /** Rolling stock length in mm */


### PR DESCRIPTION
This commit fixes various comments from my review for PR #86. The PR has been merged while I was reviewing it, so we decided I can directly submit a new one with my fixes.

Details:
- Fixes all typos from proportionnal to proportional
- Fixes React.XXX as import { XXX } from 'react'
- Refactors Manchette.tsx code to have a single, more readable setState
- Removes magic zoom boundaries and replace them with proper consts
- Fixes operationalPointsHeight so that it does not mutate things anymore
- Rewrites calcOperationalPointsToDisplay with simpler code and some comment, to help make it maintainable
- Actually stops displaying OperationalPoint with display: false