### PR TITLE
 ui-warpedmap: fix path when loading data in stories

### DIFF
--- a/ui-warped-map/src/stories/Algorithms.tsx
+++ b/ui-warped-map/src/stories/Algorithms.tsx
@@ -100,7 +100,7 @@ const AlgorithmsShowcase: FC<{ path: Feature<LineString>; warpingOptions: Warpin
 const Algorithms: FC<{ path: string } & WarpingOptions> = (props) => {
   const { path: pathName, ...warpingOptions } = props;
   const pathState = useAsyncMemo(
-    () => fetch(`/${pathName}.json`).then((res) => res.json() as Promise<Feature<LineString>>),
+    () => fetch(`./${pathName}.json`).then((res) => res.json() as Promise<Feature<LineString>>),
     [pathName]
   );
   const path = pathState.type === 'ready' ? pathState.data : null;

--- a/ui-warped-map/src/stories/SampleMap.tsx
+++ b/ui-warped-map/src/stories/SampleMap.tsx
@@ -26,7 +26,7 @@ const PATH_LAYER: Omit<LineLayer, 'source-layer'> = {
 
 const SampleMap: FC<{ path: string }> = ({ path: pathName }) => {
   const pathState = useAsyncMemo(
-    () => fetch(`/${pathName}.json`).then((res) => res.json() as Promise<Feature<LineString>>),
+    () => fetch(`./${pathName}.json`).then((res) => res.json() as Promise<Feature<LineString>>),
     [pathName]
   );
   const path = pathState.type === 'ready' ? pathState.data : null;


### PR DESCRIPTION
Stories for the warped map are broken on the GH pages, due to the data url which assumes that the path is `/`.
Check https://openrailassociation.github.io/osrd-ui/?path=/story/warpedmap-sample-maps--path-short

I have a 404 on https://openrailassociation.github.io/nantes-ancenis.json
But https://openrailassociation.github.io/osrd-ui/nantes-ancenis.json works ! 

