### PR TITLE
manchette: drop extraneous scroll event listener

### DIFF
--- a/ui-manchette/src/components/Manchette.tsx
+++ b/ui-manchette/src/components/Manchette.tsx
@@ -135,16 +135,14 @@ const Manchette: FC<ManchetteProps> = ({
   useIsOverflow(manchette, checkOverflow);
 
   useEffect(() => {
-    window.addEventListener('scroll', handleScroll, { passive: true });
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);
 
     return () => {
-      window.removeEventListener('scroll', handleScroll);
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
     };
-  }, [handleScroll, handleKeyDown, handleKeyUp]);
+  }, [handleKeyDown, handleKeyUp]);
 
   useEffect(() => {
     const computedOperationalPoints = calcOperationalPointsToDisplay(
@@ -186,7 +184,7 @@ const Manchette: FC<ManchetteProps> = ({
         style={{ height: `${height}px` }}
         onScroll={handleScroll}
       >
-        <div className="manchette-container ">
+        <div className="manchette-container">
           <div
             className=" bg-ambientB-10 border-r border-grey-30"
             style={{ minHeight: `${INITIAL_OP_LIST_HEIGHT}px` }}


### PR DESCRIPTION
We already listen for scroll events on the manchette div. The listener performs actions which depend on the manchette div scroll position only. No need to listen for window scroll.