### PR TITLE
manchette: fix action toolbar blur effect on Firefox

### DIFF
--- a/ui-manchette/src/styles/manchette.css
+++ b/ui-manchette/src/styles/manchette.css
@@ -8,9 +8,6 @@
   .manchette {
     overflow-y: auto;
     overflow-x: hidden;
-    -webkit-border-bottom-left-radius: 4px;
-    -moz-border-radius-bottomleft: 4px;
-    border-bottom-left-radius: 4px;
 
     &-actions {
       background-color: rgba(250, 249, 245, 0.6);


### PR DESCRIPTION
[Firefox has a bug][1] with backdrop filters when the following conditions are met:

- A container has a scrollbar and a border radius set
- One of its children has position set to sticky

In this case the backdrop filter isn't applied.

Here we don't actually need the border radius on the parent, because it has no background and  its own parent has the border radius.

No visual change intended apart from enabling the blur effect.

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1803813