### PR TITLE
speedspacechart: fix crash on empty stops

### DIFF
--- a/ui-speedspacechart/src/components/helpers/drawElements/reticle.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/reticle.ts
@@ -36,6 +36,10 @@ export const drawCursor = ({ ctx, width, height, store }: DrawFunctionParams) =>
     powerRestrictions,
   } = store;
 
+  if (stops.length === 0) {
+    return;
+  }
+
   ctx.strokeStyle = 'rgb(0, 0, 0)';
   ctx.lineWidth = 1;
   ctx.font = 'normal 12px IBM Plex Sans';


### PR DESCRIPTION
A similar check already exists in drawStep().

Reported by @Tguisnet and @maelysLeratRosso.

Closes: https://github.com/OpenRailAssociation/osrd/issues/8611