### PR TITLE
setup: make npm run storybook work

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "npm run build --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
-    "storybook": "npm start --workspace='@osrd-project/storybook'",
+    "storybook": "npm start --workspace=@osrd-project/storybook",
     "lerna:changed": "lerna changed",
     "lerna:diff": "lerna diff",
     "lerna": "lerna",


### PR DESCRIPTION
When running `npm run storybook`, I currently get this result: 

```
$ npm run storybook

> @osrd-project/root@0.0.1-dev storybook
> npm start --workspace='@osrd-project/storybook'

npm ERR! No workspaces found:
npm ERR!   --workspace='@osrd-project/storybook'
```

Removing the `'` around the name of the workspace solves it.