### PR TITLE
ui-manchette: fix crash when OP list is empty

### DIFF
--- a/ui-manchette/src/components/helpers.ts
+++ b/ui-manchette/src/components/helpers.ts
@@ -19,7 +19,7 @@ export const calcOperationalPointsToDisplay = (
 ): StyledOperationalPointType[] => {
   // For proportional display, we only display points that do not overlap with
   // the last displayed point:
-  if (isProportional && operationalPoints.length >= 0) {
+  if (isProportional && operationalPoints.length > 0) {
     // We start with the first operational point:
     const result: StyledOperationalPointType[] = [
       { ...operationalPoints[0], display: true, styles: {} },


### PR DESCRIPTION
Array.length always returns a value >= 0, thus the check was always true. We don't want to enter that if with a zero length array, because we assume Array.at(n) returns a non-undefined value in there.