### PR TITLE
Remove min speed management for speed space chart

### DIFF
--- a/ui-speedspacechart/src/__tests__/utils.spec.ts
+++ b/ui-speedspacechart/src/__tests__/utils.spec.ts
@@ -9,7 +9,7 @@ import {
   getLinearLayersDisplayedHeight,
   maxPositionValue,
   positionOnGraphScale,
-  speedRangeValues,
+  maxSpeedValue,
   slopesValues,
   binarySearch,
   positionToPosX,
@@ -92,12 +92,10 @@ describe('getGraphOffsets', () => {
   });
 });
 
-describe('speedRangeValues', () => {
-  it('should return the correct minSpeed, maxSpeed and speedRange', () => {
-    const { minSpeed, maxSpeed, speedRange } = speedRangeValues(store);
-    expect(minSpeed).toBe(10);
+describe('maxSpeedValue', () => {
+  it('should return the correct maxSpeed', () => {
+    const maxSpeed = maxSpeedValue(store);
     expect(maxSpeed).toBe(30);
-    expect(speedRange).toBe(20);
   });
 });
 

--- a/ui-speedspacechart/src/components/helpers/drawElements/axisY.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/axisY.ts
@@ -1,6 +1,6 @@
 import type { DrawFunctionParams } from '../../../types/chartTypes';
 import { MARGINS, TICK_TITLE_MARGINS } from '../../const';
-import { clearCanvas, speedRangeValues } from '../../utils';
+import { clearCanvas, maxSpeedValue } from '../../utils';
 
 const { MARGIN_LEFT, MARGIN_TOP, MARGIN_BOTTOM, CURVE_MARGIN_TOP, MARGIN_RIGHT } = MARGINS;
 const { Y_LEFT_VERTICAL, Y_LEFT_HORIZONTAL } = TICK_TITLE_MARGINS;
@@ -8,7 +8,7 @@ const TICK_WIDTH = 6;
 const TEXT_POSITION_X = 36;
 
 export const drawAxisY = ({ ctx, width, height, store }: DrawFunctionParams) => {
-  const { maxSpeed } = speedRangeValues(store);
+  const maxSpeed = maxSpeedValue(store);
 
   clearCanvas(ctx, width, height);
 

--- a/ui-speedspacechart/src/components/helpers/drawElements/curve.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/curve.ts
@@ -5,7 +5,7 @@ import type {
   LayerData,
 } from '../../../types/chartTypes';
 import { MARGINS } from '../../const';
-import { clearCanvas, maxPositionValue, speedRangeValues } from '../../utils';
+import { clearCanvas, maxPositionValue, maxSpeedValue } from '../../utils';
 
 const { CURVE_MARGIN_TOP, CURVE_MARGIN_SIDES } = MARGINS;
 
@@ -14,7 +14,7 @@ const drawSpecificCurve = (
   canvasConfig: CanvasConfig,
   specificSpeeds: LayerData<number>[]
 ) => {
-  const { minSpeed, speedRange, maxPosition, ratioX } = curveConfig;
+  const { maxSpeed, maxPosition, ratioX } = curveConfig;
   const { width, height, ctx } = canvasConfig;
 
   const adjustedWidth = width - CURVE_MARGIN_SIDES;
@@ -24,7 +24,7 @@ const drawSpecificCurve = (
 
   return specificSpeeds.forEach(({ position, value }) => {
     // normalize speed based on range of values
-    const normalizedSpeed = (value - minSpeed) / speedRange;
+    const normalizedSpeed = value / maxSpeed;
     const x = position.start * xcoef + halfCurveMarginSides;
     const y = height - normalizedSpeed * adjustedHeight;
     ctx.lineTo(x, y);
@@ -39,7 +39,7 @@ export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => 
   ctx.save();
   ctx.translate(leftOffset, 0);
 
-  const { minSpeed, speedRange } = speedRangeValues(store);
+  const maxSpeed = maxSpeedValue(store);
   const maxPosition = maxPositionValue(store);
 
   ctx.lineWidth = 0.5;
@@ -47,7 +47,7 @@ export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => 
   ctx.strokeStyle = 'rgb(17, 101, 180, 0.5)';
 
   ctx.beginPath();
-  drawSpecificCurve({ minSpeed, speedRange, maxPosition, ratioX }, { width, height, ctx }, speeds);
+  drawSpecificCurve({ maxSpeed, maxPosition, ratioX }, { width, height, ctx }, speeds);
   ctx.closePath();
   ctx.fill();
 
@@ -58,11 +58,7 @@ export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => 
   ctx.globalCompositeOperation = 'destination-out';
 
   ctx.beginPath();
-  drawSpecificCurve(
-    { minSpeed, speedRange, maxPosition, ratioX },
-    { width, height, ctx },
-    ecoSpeeds
-  );
+  drawSpecificCurve({ maxSpeed, maxPosition, ratioX }, { width, height, ctx }, ecoSpeeds);
   ctx.closePath();
   ctx.fill();
   ctx.globalCompositeOperation = 'source-over';

--- a/ui-speedspacechart/src/components/helpers/drawElements/reticle.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/reticle.ts
@@ -5,7 +5,7 @@ import {
   binarySearch,
   getAdaptiveHeight,
   maxPositionValue,
-  speedRangeValues,
+  maxSpeedValue,
   interpolate,
   positionToPosX,
   getCursorPosition,
@@ -60,7 +60,7 @@ export const drawCursor = ({ ctx, width, height, store }: DrawFunctionParams) =>
   let modeText = '';
   let reticleY = 0;
 
-  const { maxSpeed } = speedRangeValues(store);
+  const maxSpeed = maxSpeedValue(store);
   const maxPosition = maxPositionValue(store);
 
   const heightWithoutLayers = getAdaptiveHeight(height, layersDisplay, false);

--- a/ui-speedspacechart/src/components/utils.ts
+++ b/ui-speedspacechart/src/components/utils.ts
@@ -8,12 +8,6 @@ import {
 } from './const';
 import type { LayerData, Store } from '../types/chartTypes';
 
-type SpeedRangeValues = {
-  minSpeed: number;
-  maxSpeed: number;
-  speedRange: number;
-};
-
 type SlopesValues = {
   minGradient: number;
   maxGradient: number;
@@ -29,15 +23,12 @@ export const getGraphOffsets = (width: number, height: number, declivities?: boo
 
 /**
  * /**
- * Given a store including a list of speed data, return the minSpeed, maxSpeed and speedRange
+ * Given a store including a list of speed data, return the maxSpeed
  * @param store
  */
-export const speedRangeValues = (store: Store): SpeedRangeValues => {
+export const maxSpeedValue = (store: Store) => {
   const speeds = store.speeds;
-  const minSpeed = Math.min(...speeds.map(({ value }) => value));
-  const maxSpeed = Math.max(...speeds.map(({ value }) => value));
-  const speedRange = maxSpeed - minSpeed;
-  return { minSpeed, maxSpeed, speedRange };
+  return Math.max(...speeds.map(({ value }) => value));
 };
 
 /**

--- a/ui-speedspacechart/src/types/chartTypes.ts
+++ b/ui-speedspacechart/src/types/chartTypes.ts
@@ -69,8 +69,7 @@ export type Store = Data & {
 };
 
 export type CurveConfig = {
-  minSpeed: number;
-  speedRange: number;
+  maxSpeed: number;
   maxPosition: number;
   ratioX: number;
 };


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is dependent of the https://github.com/OpenRailAssociation/osrd-ui/pull/455

Reasons why I want to remove this behavior:

- Min speed was only handled to display curves (but not for the Y-axis)
  - Results in bugs
- This value will always be 0 except for trains that matches all of these conditions:
  - No stops
  - Starts with a speed higher than 0
  - Finishes with a speed higher than 0
- No mock-up shows that we should handle differently these trains.
- It seems to me to require a great deal of precaution to manage these trains differently when they are rare (or even non-existent).
- I don't see the user interest in modifying the base of the Y axis for these trains.