### PR TITLE
ui-core: fix checkbox label

### DIFF
--- a/ui-core/src/components/inputs/Checkbox/Checkbox.tsx
+++ b/ui-core/src/components/inputs/Checkbox/Checkbox.tsx
@@ -5,7 +5,7 @@ import cx from 'classnames';
 import useFocusByTab from '../../../hooks/useFocusByTab';
 
 export type CheckboxProps = InputHTMLAttributes<HTMLInputElement> & {
-  label: string;
+  label?: string;
   small?: boolean;
   hint?: string;
   isIndeterminate?: boolean;
@@ -49,7 +49,7 @@ const Checkbox = ({
         {...rest}
       />
       <span className={cx('checkmark', { 'focused-by-tab': isFocusByTab })}></span>
-      <div className="label">{label}</div>
+      {label && <div className="label">{label}</div>}
       {hint && <span className="hint">{hint}</span>}
     </label>
   );


### PR DESCRIPTION
As label was non optional and has a hard-coded width, even by passing an empty string inside it, the label was taking space in the dom