### PR TITLE
Speedspacechart fix curves

### DIFF
--- a/ui-speedspacechart/src/components/helpers/drawElements/curve.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/curve.ts
@@ -1,34 +1,35 @@
-import type {
-  CanvasConfig,
-  CurveConfig,
-  DrawFunctionParams,
-  LayerData,
-} from '../../../types/chartTypes';
+import type { DrawFunctionParams, LayerData } from '../../../types/chartTypes';
 import { MARGINS } from '../../const';
 import { clearCanvas, maxPositionValue, maxSpeedValue } from '../../utils';
 
 const { CURVE_MARGIN_TOP, CURVE_MARGIN_SIDES } = MARGINS;
 
-const drawSpecificCurve = (
-  curveConfig: CurveConfig,
-  canvasConfig: CanvasConfig,
+const computeCurvePoints = (
+  canvasConfig: { width: number; height: number },
+  curveConfig: { maxSpeed: number; maxPosition: number; ratioX: number },
   specificSpeeds: LayerData<number>[]
 ) => {
   const { maxSpeed, maxPosition, ratioX } = curveConfig;
-  const { width, height, ctx } = canvasConfig;
+  const { width, height } = canvasConfig;
 
   const adjustedWidth = width - CURVE_MARGIN_SIDES;
   const halfCurveMarginSides = CURVE_MARGIN_SIDES / 2;
   const adjustedHeight = height - CURVE_MARGIN_TOP;
   const xcoef = (adjustedWidth / maxPosition) * ratioX;
+  const points: { x: number; y: number }[] = [];
 
-  return specificSpeeds.forEach(({ position, value }) => {
+  specificSpeeds.forEach(({ position, value }) => {
     // normalize speed based on range of values
     const normalizedSpeed = value / maxSpeed;
     const x = position.start * xcoef + halfCurveMarginSides;
     const y = height - normalizedSpeed * adjustedHeight;
-    ctx.lineTo(x, y);
+    points.push({ x, y });
   });
+
+  // Close the path
+  points.push({ x: maxPosition * xcoef + halfCurveMarginSides, y: height });
+  points.push({ x: halfCurveMarginSides, y: height });
+  return points;
 };
 
 export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => {
@@ -42,27 +43,49 @@ export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => 
   const maxSpeed = maxSpeedValue(store);
   const maxPosition = maxPositionValue(store);
 
-  ctx.lineWidth = 0.5;
-  ctx.fillStyle = 'rgba(17, 101, 180, 0.02)';
-  ctx.strokeStyle = 'rgb(17, 101, 180, 0.5)';
+  const curvePoints = computeCurvePoints(
+    { width, height },
+    { maxSpeed, maxPosition, ratioX },
+    speeds
+  );
+  const ecoCurvePoints = computeCurvePoints(
+    { width, height },
+    { maxSpeed, maxPosition, ratioX },
+    ecoSpeeds
+  );
+
+  // Curves must be drawn twice one for the fill and one for the stroke
+  // The stroke must not draw the last two points. They're only present to close the shape but are not part of the curve.
 
   ctx.beginPath();
-  drawSpecificCurve({ maxSpeed, maxPosition, ratioX }, { width, height, ctx }, speeds);
-  ctx.closePath();
+  ctx.lineWidth = 0.5;
+  ctx.strokeStyle = 'rgb(17, 101, 180, 0.5)';
+  ctx.fillStyle = 'rgba(17, 101, 180, 0.02)';
+  curvePoints.forEach(({ x, y }) => {
+    ctx.lineTo(x, y);
+  });
   ctx.fill();
 
+  ctx.beginPath();
+  curvePoints.slice(0, curvePoints.length - 2).forEach(({ x, y }) => {
+    ctx.lineTo(x, y);
+  });
   ctx.stroke();
 
+  ctx.beginPath();
   ctx.fillStyle = 'rgba(255, 255, 255)';
   ctx.strokeStyle = 'rgb(17, 101, 180)';
   ctx.globalCompositeOperation = 'destination-out';
+  ecoCurvePoints.forEach(({ x, y }) => {
+    ctx.lineTo(x, y);
+  });
+  ctx.fill();
 
   ctx.beginPath();
-  drawSpecificCurve({ maxSpeed, maxPosition, ratioX }, { width, height, ctx }, ecoSpeeds);
-  ctx.closePath();
-  ctx.fill();
   ctx.globalCompositeOperation = 'source-over';
-
+  ecoCurvePoints.slice(0, ecoCurvePoints.length - 2).forEach(({ x, y }) => {
+    ctx.lineTo(x, y);
+  });
   ctx.stroke();
 
   ctx.restore();

--- a/ui-speedspacechart/src/types/chartTypes.ts
+++ b/ui-speedspacechart/src/types/chartTypes.ts
@@ -68,18 +68,6 @@ export type Store = Data & {
   isSettingsPanelOpened: boolean;
 };
 
-export type CurveConfig = {
-  maxSpeed: number;
-  maxPosition: number;
-  ratioX: number;
-};
-
-export type CanvasConfig = {
-  width: number;
-  height: number;
-  ctx: CanvasRenderingContext2D;
-};
-
 export type DrawFunctionParams = {
   ctx: CanvasRenderingContext2D;
   width: number;


### PR DESCRIPTION
Curve drawing doesn't work when the train starts at non-zero speed/ends at non-zero speed.

fixes https://github.com/OpenRailAssociation/osrd/issues/8333

## Before

![image](https://github.com/user-attachments/assets/a2cff81e-20a8-4844-b269-30e6cfce5a53)


## After

![image](https://github.com/user-attachments/assets/347d83fc-3105-42fa-bb64-fb4e98b8bdc5)
