### PR TITLE
bugfix_#275: Fixed spelling in Checkbox storybook

### DIFF
--- a/ui-core/src/stories/Checkbox.stories.tsx
+++ b/ui-core/src/stories/Checkbox.stories.tsx
@@ -30,7 +30,7 @@ export const Hint: Story = {
     hint: 'Without salt, sorry',
   },
 };
-export const Indterminate: Story = {
+export const Indeterminate: Story = {
   args: {
     label: 'Indeterminate',
     isIndeterminate: true,


### PR DESCRIPTION
# CHANGELOG

* Bugfix_#275: Fixed spelling in Checkbox storybook

Tested, storybook working fine

![image](https://github.com/user-attachments/assets/d117ff73-716f-496c-a304-29ce3c8d44d1)
