### PR TITLE
ui-core: nuke value in Select

### DIFF
--- a/ui-core/src/components/Select.tsx
+++ b/ui-core/src/components/Select.tsx
@@ -12,11 +12,8 @@ export type SelectProps<T> = Omit<
     options: Array<T>;
     value: T;
     getOptionLabel: (option: T) => string;
-    getOptionValue: (option: T) => string;
     onChange: (option?: T) => void;
   };
-
-const PLACEHOLDER_VALUE = '__PLACEHOLDER__';
 
 const Select = <T,>({
   id,
@@ -31,15 +28,12 @@ const Select = <T,>({
   readOnly,
   small,
   getOptionLabel,
-  getOptionValue,
   onChange,
 }: SelectProps<T>) => {
   const [selectedOption, setSelectedOption] = useState<T | undefined>(value);
   const handleOnChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newSelectedOption =
-      e.target.value === PLACEHOLDER_VALUE
-        ? undefined
-        : options.find((option) => getOptionValue(option) === e.target.value);
+    const index = e.target.selectedIndex;
+    const newSelectedOption = options[placeholder ? index - 1 : index];
     setSelectedOption(newSelectedOption);
     onChange(newSelectedOption);
   };
@@ -64,16 +58,14 @@ const Select = <T,>({
           small,
           'read-only': readOnly,
         })}
-        value={selectedOption ? getOptionValue(selectedOption) : undefined}
         required={required}
         disabled={disabled || readOnly}
         onChange={handleOnChange}
       >
-        {placeholder && <option value={PLACEHOLDER_VALUE}>{`– ${placeholder} –`}</option>}
+        {placeholder && <option>{`– ${placeholder} –`}</option>}
         {options.map((option) => (
-          <option key={getOptionValue(option)} value={getOptionValue(option)}>
-            {getOptionLabel(option)}
-          </option>
+          /* eslint-disable-next-line react/jsx-key */
+          <option selected={option === selectedOption}>{getOptionLabel(option)}</option>
         ))}
       </select>
     </FieldWrapper>

--- a/ui-core/src/stories/Select.stories.tsx
+++ b/ui-core/src/stories/Select.stories.tsx
@@ -23,7 +23,6 @@ const meta: Meta<typeof SelectWrapper> = {
     value: options[0],
     options,
     getOptionLabel: (option: Option) => option.label,
-    getOptionValue: (option: Option) => option.value,
     // eslint-disable-next-line no-console
     onChange: (option?: Option) => console.log(option),
     small: false,


### PR DESCRIPTION
We don't really need a value here, we can just use indexes instead. This makes it easier to use Select for small lists (e.g. 3 static choices) and simplifies the code.

Discussion: https://github.com/OpenRailAssociation/osrd/pull/8838#discussion_r1766745894