### PR TITLE
ui-core: enable the user to type in the date picker

### DIFF
--- a/ui-core/src/components/inputs/datePicker/CalendarPicker.tsx
+++ b/ui-core/src/components/inputs/datePicker/CalendarPicker.tsx
@@ -15,12 +15,12 @@ export type CalendarPickerPrivateProps = {
     left: number;
   };
   calendarPickerRef: React.RefObject<HTMLDivElement>;
+  selectableSlot?: CalendarSlot;
 };
 
 export type CalendarPickerPublicProps = {
   initialDate?: Date;
   numberOfMonths?: 1 | 2 | 3;
-  selectableSlot?: CalendarSlot;
 };
 
 export type CalendarPickerProps = CalendarPickerPrivateProps & CalendarPickerPublicProps;

--- a/ui-core/src/components/inputs/datePicker/DatePicker.tsx
+++ b/ui-core/src/components/inputs/datePicker/DatePicker.tsx
@@ -9,8 +9,11 @@ import useDatePicker from './useDatePicker';
 import Input, { type InputProps } from '../Input';
 
 type BaseDatePickerProps = {
+  selectableSlot?: CalendarSlot;
   inputProps: InputProps;
   calendarPickerProps?: CalendarPickerPublicProps;
+  errorMessages?: { invalidInput?: string; invalidDate?: string };
+  width?: number;
 };
 
 export type SingleDatePickerProps = BaseDatePickerProps & {
@@ -30,6 +33,7 @@ export type DatePickerProps = SingleDatePickerProps | RangeDatePickerProps;
 export const DatePicker = (props: DatePickerProps) => {
   const {
     inputValue,
+    statusWithMessage,
     selectedSlot,
     showPicker,
     modalPosition,
@@ -38,8 +42,12 @@ export const DatePicker = (props: DatePickerProps) => {
     setShowPicker,
     handleDayClick,
     handleInputClick,
+    handleInputOnChange,
   } = useDatePicker(props);
+
   const { inputFieldWrapperClassname, ...otherInputProps } = props.inputProps;
+  const { selectableSlot } = props;
+
   return (
     <div className="date-picker">
       <div>
@@ -53,8 +61,12 @@ export const DatePicker = (props: DatePickerProps) => {
             content: <CalendarIcon />,
             onClickCallback: () => setShowPicker(!showPicker),
           }}
-          inputFieldWrapperClassname={cx('date-picker-input', inputFieldWrapperClassname)}
+          inputFieldWrapperClassname={cx('date-picker-input', inputFieldWrapperClassname, {
+            'range-mode': props.isRangeMode,
+          })}
           autoComplete="off"
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputOnChange(e.target.value)}
+          statusWithMessage={statusWithMessage}
         />
       </div>
       {showPicker && (
@@ -65,6 +77,7 @@ export const DatePicker = (props: DatePickerProps) => {
             onDayClick={handleDayClick}
             modalPosition={modalPosition}
             calendarPickerRef={calendarPickerRef}
+            selectableSlot={selectableSlot}
           />
         </div>
       )}

--- a/ui-core/src/components/inputs/datePicker/__tests__/useCalendarPicker.spec.ts
+++ b/ui-core/src/components/inputs/datePicker/__tests__/useCalendarPicker.spec.ts
@@ -97,9 +97,8 @@ describe('useCalendarPicker', () => {
 
   describe('Navigation handling', () => {
     it('should navigate to the next month correctly during the year', () => {
-      const { result } = renderHook(() =>
-        useCalendarPicker({ initialDate: new Date(2024, july, 1) })
-      );
+      const initialDate = new Date(2024, july, 1);
+      const { result } = renderHook(() => useCalendarPicker({ initialDate }));
       act(() => result.current.handleGoToNextMonth());
 
       expect(result.current.displayedMonthsStartDates[0].getMonth()).toBe(august);
@@ -107,9 +106,8 @@ describe('useCalendarPicker', () => {
     });
 
     it('should navigate to the next month correctly at the end of the year', () => {
-      const { result } = renderHook(() =>
-        useCalendarPicker({ initialDate: new Date(2024, december, 1) })
-      );
+      const initialDate = new Date(2024, december, 1);
+      const { result } = renderHook(() => useCalendarPicker({ initialDate }));
       act(() => result.current.handleGoToNextMonth());
 
       expect(result.current.displayedMonthsStartDates[0].getMonth()).toBe(january);
@@ -117,9 +115,8 @@ describe('useCalendarPicker', () => {
     });
 
     it('should navigate to the previous month correctly during the year', () => {
-      const { result } = renderHook(() =>
-        useCalendarPicker({ initialDate: new Date(2024, july, 1) })
-      );
+      const initialDate = new Date(2024, july, 1);
+      const { result } = renderHook(() => useCalendarPicker({ initialDate }));
       act(() => result.current.handleGoToPreviousMonth());
 
       expect(result.current.displayedMonthsStartDates[0].getMonth()).toBe(june);
@@ -127,9 +124,8 @@ describe('useCalendarPicker', () => {
     });
 
     it('should navigate to the previous month correctly at the start of the year', () => {
-      const { result } = renderHook(() =>
-        useCalendarPicker({ initialDate: new Date(2024, january, 1) })
-      );
+      const initialDate = new Date(2024, january, 1);
+      const { result } = renderHook(() => useCalendarPicker({ initialDate }));
       act(() => result.current.handleGoToPreviousMonth());
 
       expect(result.current.displayedMonthsStartDates[0].getMonth()).toBe(december);

--- a/ui-core/src/components/inputs/datePicker/__tests__/useDatePicker.spec.ts
+++ b/ui-core/src/components/inputs/datePicker/__tests__/useDatePicker.spec.ts
@@ -4,6 +4,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { type RangeDatePickerProps, type SingleDatePickerProps } from '..';
 import useDatePicker from '../useDatePicker';
 
+const errorMessages = {
+  invalidDate: 'Invalid date',
+  invalidInput: 'Invalid input',
+};
+
 describe('useDatePicker', () => {
   let onDayChange: RangeDatePickerProps['onDateChange'];
   let onSlotChange: SingleDatePickerProps['onDateChange'];
@@ -59,22 +64,150 @@ describe('useDatePicker', () => {
   });
 
   describe('input click handling', () => {
-    it('should show the picker and call the input onClick callback ', () => {
-      const onClickCallback = vi.fn();
+    it('should not show the picker in single date mode', () => {
       const { result } = renderHook(() =>
         useDatePicker({
-          inputProps: { id: 'id', label: 'label', onClick: onClickCallback },
+          inputProps: { id: 'id', label: 'label' },
           isRangeMode: false,
           onDateChange: onDayChange,
         })
       );
 
       act(() => {
-        result.current.handleInputClick({} as React.MouseEvent<HTMLInputElement, MouseEvent>);
+        result.current.handleInputClick();
+      });
+
+      expect(result.current.showPicker).toBe(false);
+    });
+
+    it('should show the picker in range mode', () => {
+      const { result } = renderHook(() =>
+        useDatePicker({
+          inputProps: { id: 'id', label: 'label' },
+          isRangeMode: true,
+          onDateChange: onDayChange,
+        })
+      );
+
+      act(() => {
+        result.current.handleInputClick();
       });
 
       expect(result.current.showPicker).toBe(true);
-      expect(onClickCallback).toHaveBeenCalled();
+    });
+  });
+
+  describe('input change handling', () => {
+    describe('single mode', () => {
+      it.each(['toto', '01/01/2024', '01/i'])(
+        'should show an error if the input is invalid (%i)',
+        (newValue) => {
+          const { result } = renderHook(() =>
+            useDatePicker({
+              inputProps: { id: 'id', label: 'label' },
+              isRangeMode: false,
+              onDateChange: onDayChange,
+              errorMessages,
+            })
+          );
+
+          act(() => {
+            result.current.handleInputOnChange(newValue);
+          });
+
+          expect(result.current.inputValue).toBe(newValue);
+          expect(result.current.statusWithMessage).toEqual({
+            status: 'error',
+            message: 'Invalid input',
+          });
+          expect(onDayChange).not.toBeCalled();
+        }
+      );
+
+      it('should update the input value if the date string is not complete', () => {
+        const { result } = renderHook(() =>
+          useDatePicker({
+            inputProps: { id: 'id', label: 'label' },
+            isRangeMode: false,
+            onDateChange: onDayChange,
+            errorMessages,
+          })
+        );
+
+        act(() => {
+          result.current.handleInputOnChange('3/04/24');
+        });
+
+        expect(result.current.inputValue).toBe('3/04/24');
+        expect(result.current.statusWithMessage).toBe(undefined);
+        expect(onDayChange).not.toBeCalled();
+      });
+
+      it('should show an error if the date is not within the selectable slot', () => {
+        const { result } = renderHook(() =>
+          useDatePicker({
+            selectableSlot: { start: new Date(2024, 0, 1), end: new Date(2024, 1, 1) },
+            inputProps: { id: 'id', label: 'label' },
+            isRangeMode: false,
+            onDateChange: onDayChange,
+            errorMessages,
+          })
+        );
+
+        act(() => {
+          result.current.handleInputOnChange('03/04/24');
+        });
+
+        expect(result.current.inputValue).toBe('03/04/24');
+        expect(result.current.statusWithMessage).toEqual({
+          status: 'error',
+          message: 'Invalid date',
+        });
+        expect(onDayChange).not.toBeCalled();
+      });
+
+      it('should update the parent value is the date is valid', () => {
+        const { result } = renderHook(() =>
+          useDatePicker({
+            inputProps: { id: 'id', label: 'label' },
+            isRangeMode: false,
+            onDateChange: onDayChange,
+            errorMessages,
+          })
+        );
+
+        act(() => {
+          result.current.handleInputOnChange('01/02/24');
+        });
+
+        expect(result.current.inputValue).toBe('01/02/24');
+        expect(result.current.statusWithMessage).toBe(undefined);
+        expect(onDayChange).toHaveBeenCalledWith(new Date(2024, 1, 1));
+      });
+    });
+
+    describe('range mode', () => {
+      it('should do nothing in range mode', () => {
+        const { result } = renderHook(() =>
+          useDatePicker({
+            value: { start: new Date(2024, 0, 1), end: null },
+            inputProps: {
+              id: 'id',
+              label: 'label',
+            },
+            isRangeMode: true,
+            onDateChange: onDayChange,
+            errorMessages,
+          })
+        );
+
+        act(() => {
+          result.current.handleInputOnChange('01/02/24');
+        });
+
+        expect(result.current.inputValue).toBe('01/01/24 - ');
+        expect(onDayChange).not.toBeCalled();
+      });
     });
   });
 });

--- a/ui-core/src/components/inputs/datePicker/useCalendarPicker.ts
+++ b/ui-core/src/components/inputs/datePicker/useCalendarPicker.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { type CalendarPickerProps } from './CalendarPicker';
 import { generateSequentialDates, validateSlots } from './utils';
@@ -10,9 +10,9 @@ export default function useCalendarPicker({
   numberOfMonths = 1,
 }: Omit<CalendarPickerProps, 'modalPosition' | 'calendarPickerRef' | 'onDayClick'>) {
   validateSlots(selectedSlot, selectableSlot, initialDate);
-  const initialActiveDate =
-    initialDate ?? selectedSlot?.start ?? selectableSlot?.start ?? new Date();
-  const [activeDate, setActiveDate] = useState<Date>(initialActiveDate);
+
+  const [activeDate, setActiveDate] = useState(new Date());
+
   const displayedMonthsStartDates = generateSequentialDates(activeDate, numberOfMonths);
 
   const activeYear = activeDate.getFullYear();
@@ -47,6 +47,10 @@ export default function useCalendarPicker({
       setActiveDate(new Date(nextActiveYear, nextActiveMonth, 1));
     }
   };
+
+  useEffect(() => {
+    setActiveDate(initialDate ?? selectedSlot?.start ?? selectableSlot?.start ?? new Date());
+  }, [initialDate, selectedSlot, selectableSlot]);
 
   return {
     displayedMonthsStartDates,

--- a/ui-core/src/components/inputs/datePicker/useDatePicker.ts
+++ b/ui-core/src/components/inputs/datePicker/useDatePicker.ts
@@ -1,25 +1,40 @@
 import { useState, useRef, useEffect } from 'react';
 
 import type { DatePickerProps } from './DatePicker';
-import { computeNewSelectedSlot, formatInputValue, formatValueToSlot } from './utils';
+import {
+  computeNewSelectedSlot,
+  containsOnlyNumbersAndSlashes,
+  formatInputValue,
+  formatValueToSlot,
+  isWithinInterval,
+} from './utils';
 import { useModalPosition } from '../../../hooks/useModalPosition';
 import useOutsideClick from '../../../hooks/useOutsideClick';
+import type { StatusWithMessage } from '../StatusMessage';
 
 const MODAL_HORIZONTAL_OFFSET = -24;
 const MODAL_VERTICAL_OFFSET = 3;
 
+// Regex for "xx/xx/xx"
+const SINGLE_DATE_REGEX = /^\d{2}\/\d{2}\/\d{2}$/;
+
 export default function useDatePicker(datePickerProps: DatePickerProps) {
-  const { inputProps, value, isRangeMode, onDateChange } = datePickerProps;
+  const { value, isRangeMode, selectableSlot, errorMessages, onDateChange } = datePickerProps;
   const [showPicker, setShowPicker] = useState(false);
   const [inputValue, setInputValue] = useState(formatInputValue(datePickerProps));
   const [selectedSlot, setSelectedSlot] = useState(formatValueToSlot(datePickerProps));
+  const [statusWithMessage, setStatusWithMessage] = useState<StatusWithMessage>();
 
   const calendarPickerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   useOutsideClick(calendarPickerRef, (e) => {
     // Do not close the picker if any children in input wrapper is clicked.
     // This wrapper include, the input itself, the trailing content (which contains the calendar icon) and the leading content
-    if (inputRef.current && inputRef.current.parentElement?.contains(e.target as Node)) return;
+    if (
+      inputRef.current &&
+      inputRef.current.parentElement?.parentElement?.contains(e.target as Node)
+    )
+      return;
     setShowPicker(false);
   });
   const { calculatePosition, modalPosition } = useModalPosition(
@@ -29,9 +44,10 @@ export default function useDatePicker(datePickerProps: DatePickerProps) {
     MODAL_HORIZONTAL_OFFSET
   );
 
-  const handleInputClick = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
-    setShowPicker(true);
-    inputProps.onClick?.(e);
+  const handleInputClick = () => {
+    if (isRangeMode) {
+      setShowPicker(true);
+    }
   };
 
   const handleDayClick = (clickedDate: Date) => {
@@ -43,12 +59,48 @@ export default function useDatePicker(datePickerProps: DatePickerProps) {
     }
   };
 
+  const handleInputOnChange = (newValue: string) => {
+    if (isRangeMode) {
+      return;
+    }
+
+    setInputValue(newValue);
+    const inputIsDate = SINGLE_DATE_REGEX.test(newValue);
+
+    if (inputIsDate) {
+      const [day, month, year] = newValue.split('/').map(Number);
+      const date = new Date(year + 2000, month - 1, day);
+
+      if (!isNaN(date.getTime()) && isWithinInterval(date, selectableSlot) && onDateChange) {
+        onDateChange(date);
+      } else {
+        setStatusWithMessage({ status: 'error', message: errorMessages?.invalidDate });
+      }
+      return;
+    }
+
+    if (containsOnlyNumbersAndSlashes(newValue) && newValue.length < 8) {
+      setStatusWithMessage(undefined);
+      return;
+    }
+    setStatusWithMessage({
+      status: 'error',
+      message: errorMessages?.invalidInput,
+    });
+  };
+
   useEffect(() => {
     if (showPicker) calculatePosition();
   }, [showPicker, calculatePosition]);
 
   useEffect(() => {
-    setInputValue(formatInputValue(datePickerProps));
+    const newInput = formatInputValue(datePickerProps);
+    if (newInput !== inputValue) {
+      // we only set the input value if it has changed
+      // otherwise the user loses the focus
+      setInputValue(newInput);
+    }
+    setStatusWithMessage(undefined);
     setSelectedSlot(formatValueToSlot(datePickerProps));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
@@ -56,6 +108,7 @@ export default function useDatePicker(datePickerProps: DatePickerProps) {
   return {
     showPicker,
     inputValue,
+    statusWithMessage,
     selectedSlot,
     modalPosition,
     inputRef,
@@ -63,5 +116,6 @@ export default function useDatePicker(datePickerProps: DatePickerProps) {
     setShowPicker,
     handleDayClick,
     handleInputClick,
+    handleInputOnChange,
   };
 }

--- a/ui-core/src/components/inputs/datePicker/utils.ts
+++ b/ui-core/src/components/inputs/datePicker/utils.ts
@@ -8,6 +8,8 @@ export const INVALID_SELECTED_SLOT_BASED_ON_SELECTABLE_SLOT_ERROR =
   'selectedSlot must be within selectableSlot';
 export const INVALID_INITIAL_DATE_ERROR = 'initialDate must be within selectableSlot';
 
+export const containsOnlyNumbersAndSlashes = (s: string) => /^[0-9/]+$/.test(s);
+
 /**
  * Normalize the given date to midnight
  * @param date The date to normalize

--- a/ui-core/src/stories/DatePicker.stories.tsx
+++ b/ui-core/src/stories/DatePicker.stories.tsx
@@ -10,6 +10,8 @@ import {
   type CalendarSlot,
 } from '../components/inputs/datePicker';
 import '@osrd-project/ui-core/dist/theme.css';
+import './stories.css';
+import { formatDateString } from '../components/inputs/datePicker/utils';
 
 const now = new Date();
 const endSelectableDate = new Date(now);
@@ -38,11 +40,17 @@ const DatePickerStory = (props: DatePickerProps) => {
     );
   } else {
     return (
-      <DatePicker
-        {...props}
-        value={value as SingleDatePickerProps['value']}
-        onDateChange={onDayChange}
-      />
+      <div className="date-picker-story-wrapper">
+        <DatePicker
+          {...props}
+          value={value as SingleDatePickerProps['value']}
+          onDateChange={onDayChange}
+          errorMessages={{
+            invalidDate: `Please select a valid date between ${formatDateString(selectableSlot.start)} and ${formatDateString(selectableSlot.end)}`,
+            invalidInput: 'Please enter a valid date dd/mm/yy',
+          }}
+        />
+      </div>
     );
   }
 };
@@ -64,13 +72,14 @@ const meta: Meta<typeof DatePicker> = {
     },
   },
   args: {
+    selectableSlot,
     calendarPickerProps: {
       numberOfMonths: 1,
-      selectableSlot,
     },
     inputProps: {
       id: 'date-picker',
       label: 'Select a date',
+      inputFieldWrapperClassname: 'date-picker-input-wrapper',
     },
   },
   render: (props) => <DatePickerStory {...props} />,

--- a/ui-core/src/stories/stories.css
+++ b/ui-core/src/stories/stories.css
@@ -1,0 +1,5 @@
+.date-picker-story-wrapper {
+  .date-picker-input-wrapper {
+    width: 300px;
+  }
+}

--- a/ui-core/src/styles/inputs/datePicker.css
+++ b/ui-core/src/styles/inputs/datePicker.css
@@ -5,8 +5,10 @@
         @apply text-primary-60;
       }
     }
-    .input {
-      caret-color: transparent;
+    &.range-mode {
+      .input {
+        caret-color: transparent;
+      }
     }
   }
 


### PR DESCRIPTION
closes #526 

Some remarks:
- when the user clicks on the input, the calendar is not opened automatically anymore
- if the user types a string which is not a date, the date value is not updated
- if the user types a valid string but the date is not in the selectable slot, then an error is displayed (the invalid date is not updated in the parent component)
- if the calendar is opened and the user enters a valid date, then the calendar view is correctly updated
- if an invalid date is entered and the user picks a date from the calendar, then the error is not displayed anymore

Technical remarks:
- I moved the selectableSlot props so it is more easier to access it

When the input is invalid:
![image](https://github.com/user-attachments/assets/100ea7a3-0fcc-46a0-a897-f3759dab28bc)