### PR TITLE
ui-core: accept undefined as Select value

### DIFF
--- a/ui-core/src/components/Select.tsx
+++ b/ui-core/src/components/Select.tsx
@@ -10,7 +10,7 @@ export type SelectProps<T> = Omit<
 > &
   Omit<FieldWrapperProps, 'children'> & {
     options: Array<T>;
-    value: T;
+    value?: T;
     getOptionLabel: (option: T) => string;
     getOptionValue: (option: T) => string;
     onChange: (option?: T) => void;


### PR DESCRIPTION
When a placeholder is used, the value of a Select can be undefined, as reflected in the type of the onChange callback. However the component user had no way to reset the value of the Select from the outside via the value property. Make it optional to fix that.

Discussion: https://github.com/OpenRailAssociation/osrd/pull/8838#discussion_r1774839347