### PR TITLE
ui-speedspacechart: speed limit tags enhancements

### DIFF
--- a/ui-speedspacechart/src/components/layers/SpeedLimitTagsLayer.tsx
+++ b/ui-speedspacechart/src/components/layers/SpeedLimitTagsLayer.tsx
@@ -11,7 +11,19 @@ type SpeedLimitTagsLayerProps = {
   store: Store;
 };
 const TOOLTIP_HEIGHT = 40;
-const MARGIN_ADJUSTMENT = 2;
+const LEFT_MARGIN = 52;
+const RIGHT_MARGIN = 16;
+const TOOLTIP_WIDTH = 238;
+
+const constrainTooltipPosition = (cursorX: number, width: number, tooltipWidth: number) => {
+  if (cursorX - tooltipWidth / 2 < LEFT_MARGIN) {
+    return LEFT_MARGIN + tooltipWidth / 2;
+  }
+  if (cursorX + tooltipWidth / 2 > width - RIGHT_MARGIN) {
+    return width - RIGHT_MARGIN - tooltipWidth / 2;
+  }
+  return cursorX;
+};
 
 const SpeedLimitTagsLayer = ({ width, marginTop, store }: SpeedLimitTagsLayerProps) => {
   const canvas = useRef<HTMLCanvasElement>(null);
@@ -39,8 +51,8 @@ const SpeedLimitTagsLayer = ({ width, marginTop, store }: SpeedLimitTagsLayerPro
       />
       {tooltip.current && (
         <Tooltip
-          cursorX={tooltip.current.cursorX}
-          cursorY={marginTop - TOOLTIP_HEIGHT - MARGIN_ADJUSTMENT}
+          cursorX={constrainTooltipPosition(tooltip.current.cursorX, width, TOOLTIP_WIDTH)}
+          cursorY={tooltip.current.cursorY - TOOLTIP_HEIGHT}
           height={TOOLTIP_HEIGHT}
           text={tooltip.current.text}
         />

--- a/ui-speedspacechart/src/stories/assets/speed_limit_tags_PMP_LM.ts
+++ b/ui-speedspacechart/src/stories/assets/speed_limit_tags_PMP_LM.ts
@@ -4,15 +4,19 @@ export type SpeedLimitTags = {
 };
 
 export const speedLimitTags: SpeedLimitTags = {
-  boundaries: [0, 25000000, 65000000, 95000000, 125000000, 201408607],
+  boundaries: [0, 5900000, 35915000, 95000000, 125000000, 201408600],
   values: [
-    { speed_limit_tags_type: 'tag', tag_name: 'MA100', color: '#494641' },
     { speed_limit_tags_type: 'tag', tag_name: 'EVO', color: '#216482' },
+    {
+      speed_limit_tags_type: 'tag',
+      tag_name: 'MA100',
+      color: '#494641',
+    },
     { speed_limit_tags_type: 'tag', tag_name: 'incompatible', color: '#EAA72B' },
     {
       speed_limit_tags_type: 'tag',
-      tag_name: 'UU',
-      color: '#D91C1C',
+      tag_name: 'MA100',
+      color: '#494641',
     },
     { speed_limit_tags_type: 'tag', tag_name: 'missing_from_train', color: '#94918E' },
   ],


### PR DESCRIPTION
- adding logic to make the tooltip follow the cursor move horizontally and vertically
- sticking the tooltip to the chart when the cursor goes outside
- adding logic to prevent text going outside its tag
Signed-off-by: Mathieu <mathieu.coulibaly@sncf.fr>