### PR TITLE
github: switch dependabot to weekly, add storybook group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,12 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
     commit-message:
       prefix: "dependency:"
     open-pull-requests-limit: 100


### PR DESCRIPTION
Daily upgrades are a bit too spammy and we don't need to be _that_ up-to-date, so switch to weekly updates.

Group all storybook upgrades altogether in a single PR.