### PR TITLE
ui-manchette-with-spacetimechart: fix spacetimechart scaling if hidde…

### DIFF
--- a/ui-manchette-with-spacetimechart/src/__tests__/helpers.spec.ts
+++ b/ui-manchette-with-spacetimechart/src/__tests__/helpers.spec.ts
@@ -221,7 +221,7 @@ describe('getScales', () => {
       yZoom: 1,
     });
 
-    expect(result).toHaveLength(1);
+    expect(result).toHaveLength(2);
     expect(result[0].size).toBeDefined();
     expect(result[0].coefficient).not.toBeDefined();
   });

--- a/ui-manchette-with-spacetimechart/src/helpers.ts
+++ b/ui-manchette-with-spacetimechart/src/helpers.ts
@@ -119,6 +119,19 @@ export const getScales = (
   { height, isProportional, yZoom }: OperationalPointsOptions
 ) => {
   if (ops.length < 2) return [];
+
+  if (!isProportional) {
+    return ops.slice(0, -1).map((from, index) => {
+      const to = ops[index + 1];
+
+      return {
+        from: from.position,
+        to: to.position,
+        size: BASE_OP_HEIGHT * yZoom,
+      };
+    });
+  }
+
   const from = ops.at(0)!.position;
   const to = ops.at(-1)!.position;
 

--- a/ui-spacetimechart/src/components/SpaceTimeChart.tsx
+++ b/ui-spacetimechart/src/components/SpaceTimeChart.tsx
@@ -107,7 +107,7 @@ export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
     }
 
     const getTimePixel = getTimeToPixel(timeOrigin, timePixelOffset, timeScale);
-    const getSpacePixel = getSpaceToPixel(spaceOrigin, spacePixelOffset, spaceScaleTree);
+    const getSpacePixel = getSpaceToPixel(spacePixelOffset, spaceScaleTree);
     const getPoint = getDataToPoint(getTimePixel, getSpacePixel, timeAxis, spaceAxis);
     const getTime = getPixelToTime(timeOrigin, timePixelOffset, timeScale);
     const getSpace = getPixelToSpace(spaceOrigin, spacePixelOffset, spaceScaleTree);

--- a/ui-spacetimechart/src/utils/scales.ts
+++ b/ui-spacetimechart/src/utils/scales.ts
@@ -153,15 +153,11 @@ export function getPixelToTime(
 }
 
 export function getSpaceToPixel(
-  spaceOrigin: number,
   pixelOffset: number,
   binaryTree: NormalizedScaleTree
 ): SpaceToPixel {
   return (position: number) => {
-    const { from, pixelFrom, coefficient } = getNormalizedScaleAtPosition(
-      position - spaceOrigin,
-      binaryTree
-    );
+    const { from, pixelFrom, coefficient } = getNormalizedScaleAtPosition(position, binaryTree);
     return pixelOffset + pixelFrom + (position - from) / coefficient;
   };
 }


### PR DESCRIPTION
…n waypoints

Fix an issue where the space time chart wouldn't correspond to the manchette in linear mode when a bunch of waypoints were hidden in the middle of the path
> add a new condition in `getScales` function

Fix an issue where the space time chart wouldn't correspond to the manchette when the first x waypoints were hidden
> The code used to consider that the space origin only starts at 0 but it might not always be the case when hiding waypoints.

> [!IMPORTANT]  
> To test these changes, you need to be able to launch osrd-ui inside osrd and be on this [PR](https://github.com/OpenRailAssociation/osrd/pull/8796) (to hide waypoints on the manchette)