### PR TITLE
github: group turf updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
         patterns:
           - "storybook"
           - "@storybook/*"
+      turf:
+        patterns:
+          - "@turf/*"
     commit-message:
       prefix: "dependency:"
     open-pull-requests-limit: 100


### PR DESCRIPTION
Looking at the opened PR list from dependabot there are a whole bunch of turf updates, all failing because turf packages need to all be upgraded together.