### PR TITLE
ui-spacetimechart: add missing ConflictLayer export

### DIFF
--- a/ui-spacetimechart/src/index.ts
+++ b/ui-spacetimechart/src/index.ts
@@ -2,3 +2,4 @@ import './styles/main.css';
 
 export * from './components/SpaceTimeChart';
 export * from './components/PathLayer';
+export * from './components/ConflictLayer';

--- a/ui-spacetimechart/src/stories/layers.stories.tsx
+++ b/ui-spacetimechart/src/stories/layers.stories.tsx
@@ -4,8 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { OPERATIONAL_POINTS, PATHS, START_DATE } from './lib/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL } from './lib/utils';
-import { SpaceTimeChart, PathLayer } from '../';
-import { ConflictLayer } from '../components/ConflictLayer';
+import { ConflictLayer, SpaceTimeChart, PathLayer } from '../';
 import { KILOMETER, MINUTE } from '../lib/consts';
 
 import '@osrd-project/ui-spacetimechart/dist/theme.css';


### PR DESCRIPTION
We're not able to use the component from outside if it's not exported in index.ts.

Oversight on my end, sorry!