### PR TITLE
ui-core: make combobox filter optional

### DIFF
--- a/ui-core/src/components/inputs/ComboBox/ComboBox.tsx
+++ b/ui-core/src/components/inputs/ComboBox/ComboBox.tsx
@@ -33,7 +33,7 @@ const ComboBox = <T,>({
   customLabel,
   numberOfSuggestionsToShow = 5,
   exactSearch = false,
-  value,
+  value = '',
   small,
   onSelectSuggestion,
   disableDefaultFilter = false,
@@ -41,7 +41,7 @@ const ComboBox = <T,>({
 }: ComboBoxProps<T>) => {
   const [filteredSuggestions, setFilteredSuggestions] = useState<T[]>([]);
   const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1);
-  const [inputValue, setInputValue] = useState(value || '');
+  const [inputValue, setInputValue] = useState(value);
   const [selectedOption, setSelectedOption] = useState<T | null>(null);
   const [isInputFocused, setIsInputFocused] = useState(false);
 
@@ -84,7 +84,7 @@ const ComboBox = <T,>({
   };
 
   const icons = [
-    ...(selectedOption
+    ...(selectedOption || suggestions.some((suggestion) => getSuggestionLabel(suggestion) === value)
       ? [
           {
             icon: <X size={small ? 'sm' : 'lg'} />,

--- a/ui-core/src/components/inputs/ComboBox/ComboBox.tsx
+++ b/ui-core/src/components/inputs/ComboBox/ComboBox.tsx
@@ -23,6 +23,7 @@ export type ComboBoxProps<T> = InputProps & {
   exactSearch?: boolean;
   value?: string;
   onSelectSuggestion?: (option: T | undefined) => void;
+  disableDefaultFilter?: boolean;
 };
 
 const ComboBox = <T,>({
@@ -35,6 +36,7 @@ const ComboBox = <T,>({
   value,
   small,
   onSelectSuggestion,
+  disableDefaultFilter = false,
   ...inputProps
 }: ComboBoxProps<T>) => {
   const [filteredSuggestions, setFilteredSuggestions] = useState<T[]>([]);
@@ -46,8 +48,13 @@ const ComboBox = <T,>({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const sortedSuggestions = useMemo(
-    () => suggestions.sort((a, b) => getSuggestionLabel(a).localeCompare(getSuggestionLabel(b))),
-    [suggestions, getSuggestionLabel]
+    () =>
+      !disableDefaultFilter
+        ? [...suggestions].sort((a, b) =>
+            getSuggestionLabel(a).localeCompare(getSuggestionLabel(b))
+          )
+        : suggestions,
+    [suggestions, getSuggestionLabel, disableDefaultFilter]
   );
 
   const showSuggestions = isInputFocused && filteredSuggestions.length > 0 && !inputProps.disabled;

--- a/ui-core/src/stories/ComboBox.stories.tsx
+++ b/ui-core/src/stories/ComboBox.stories.tsx
@@ -51,7 +51,7 @@ export const WithDefaultValue: Story = {
   args: {
     label: 'Your name',
     type: 'text',
-    value: 'Manuéla',
+    value: 'Manolo',
   },
 };
 

--- a/ui-core/src/stories/ComboBox.stories.tsx
+++ b/ui-core/src/stories/ComboBox.stories.tsx
@@ -9,8 +9,9 @@ type Suggestion = { id: string; label: string };
 
 const suggestions = [
   { id: '1', label: 'Manuel' },
-  { id: '2', label: 'Manuela' },
-  { id: '3', label: 'Manuella' },
+  { id: '2', label: 'Consuela' },
+  { id: '3', label: 'Juan' },
+  { id: '4', label: 'Manolo' },
 ] as Suggestion[];
 
 const meta: Meta<typeof ComboBox> = {
@@ -95,5 +96,13 @@ export const SmallInput: Story = {
     type: 'text',
     required: true,
     small: true,
+  },
+};
+
+export const DisabledDefaultFilter: Story = {
+  args: {
+    label: 'Name',
+    type: 'text',
+    disableDefaultFilter: true,
   },
 };


### PR DESCRIPTION
This PR adds a new prop to the ComboBox component so that the default suggestion filter can be deactivated.
This modification is necessary in cases where suggestions need to be displayed in a specific non-alphabetical order.

Also closes #578 