### PR TITLE
front: input and combo box text overflow fix

### DIFF
--- a/ui-core/src/components/inputs/Input.tsx
+++ b/ui-core/src/components/inputs/Input.tsx
@@ -109,6 +109,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 'with-leading-only': leadingContent && !trailingContent,
                 'with-trailing-only': trailingContent && !leadingContent,
                 'with-leading-and-trailing': leadingContent && trailingContent,
+                [`with-icons-${withIcons.length}`]: withIcons.length > 0,
                 [statusWithMessage?.status || '']: !!statusWithMessage,
               })}
               id={id}

--- a/ui-core/src/stories/ComboBox.stories.tsx
+++ b/ui-core/src/stories/ComboBox.stories.tsx
@@ -47,6 +47,18 @@ export const Default: Story = {
   },
 };
 
+export const LongText: Story = {
+  args: {
+    label: 'Your name',
+    type: 'text',
+    suggestions: [
+      { id: '1', label: 'Very very very very very very long value 1' },
+      { id: '2', label: 'Very very very very very very long value 2' },
+    ],
+    value: 'Very very very very very very long value 1',
+  },
+};
+
 export const WithDefaultValue: Story = {
   args: {
     label: 'Your name',

--- a/ui-core/src/stories/Input.stories.tsx
+++ b/ui-core/src/stories/Input.stories.tsx
@@ -204,10 +204,30 @@ export const InputWithClearButton: Story = {
   args: {
     label: 'Your name',
     type: 'text',
-    value: 'Manuel',
+    value: 'Hubert Blaine Wolfeschlegelsteinhausenbergerdorff Sr',
     withIcons: [
       {
         icon: <X size="lg" />,
+        action: () => {},
+        className: 'chevron-icon',
+      },
+    ],
+  },
+};
+
+export const InputWithTwoIconAndLongValue: Story = {
+  args: {
+    label: 'Your name',
+    type: 'text',
+    value: 'Hubert Blaine Wolfeschlegelsteinhausenbergerdorff Sr',
+    withIcons: [
+      {
+        icon: <X size="lg" />,
+        action: () => {},
+        className: 'chevron-icon',
+      },
+      {
+        icon: <ChevronDown size="lg" />,
         action: () => {},
         className: 'chevron-icon',
       },

--- a/ui-core/src/styles/inputs/input.css
+++ b/ui-core/src/styles/inputs/input.css
@@ -25,6 +25,10 @@
     align-items: center;
     position: relative;
     width: 100%;
+
+    .input {
+      text-overflow: ellipsis;
+    }
   }
 
   .input-icons {
@@ -101,6 +105,14 @@
 
     &.with-leading-only {
       border-radius: 0 0.25rem 0.25rem 0;
+    }
+
+    &.with-icons-1 {
+      padding-right: 2.188rem;
+    }
+
+    &.with-icons-2 {
+      padding-right: 4.876rem;
     }
 
     &.with-trailing-only {


### PR DESCRIPTION
part of #596 

Fix Input overflow with icons 
<img width="329" alt="Capture d’écran 2024-10-17 à 09 33 09" src="https://github.com/user-attachments/assets/b9ab7d58-ca2b-41ec-8068-04b1691575e1">



Fix ComboBox (that use Input)
<img width="340" alt="Capture d’écran 2024-10-10 à 10 55 50" src="https://github.com/user-attachments/assets/2c87b908-ca75-4fbc-b61a-c5e03d7f0ba3">
