### PR TITLE
ui-speedspacechart: fix speedlimittags layer blinking

### DIFF
--- a/ui-speedspacechart/src/__tests__/utils.spec.ts
+++ b/ui-speedspacechart/src/__tests__/utils.spec.ts
@@ -95,22 +95,19 @@ describe('getGraphOffsets', () => {
 
 describe('maxSpeedValue', () => {
   it('should return the correct maxSpeed', () => {
-    const maxSpeed = maxSpeedValue(store);
+    const maxSpeed = maxSpeedValue(store.speeds);
     expect(maxSpeed).toBe(30);
   });
 });
 
 describe('maxPositionValue', () => {
   it('should return the correct maxPosition', () => {
-    const maxPosition = maxPositionValue(store);
+    const maxPosition = maxPositionValue(store.speeds);
     expect(maxPosition).toBe(600);
   });
 
   it('should return 0 for maxPosition if speed array is empty', () => {
-    const maxPosition = maxPositionValue({
-      ...store,
-      speeds: [],
-    });
+    const maxPosition = maxPositionValue([]);
     expect(maxPosition).toBe(0);
   });
 });

--- a/ui-speedspacechart/src/components/helpers/drawElements/axisY.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/axisY.ts
@@ -8,7 +8,7 @@ const TICK_WIDTH = 6;
 const TEXT_POSITION_X = 36;
 
 export const drawAxisY = ({ ctx, width, height, store }: DrawFunctionParams) => {
-  const maxSpeed = maxSpeedValue(store);
+  const maxSpeed = maxSpeedValue(store.speeds);
 
   clearCanvas(ctx, width, height);
 

--- a/ui-speedspacechart/src/components/helpers/drawElements/curve.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/curve.ts
@@ -44,8 +44,8 @@ export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => 
   ctx.save();
   ctx.translate(leftOffset, 0);
 
-  const maxSpeed = maxSpeedValue(store);
-  const maxPosition = maxPositionValue(store);
+  const maxSpeed = maxSpeedValue(store.speeds);
+  const maxPosition = maxPositionValue(store.speeds);
 
   const curvePoints = computeCurvePoints(
     { width, height },

--- a/ui-speedspacechart/src/components/helpers/drawElements/declivity.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/declivity.ts
@@ -8,7 +8,7 @@ export const drawDeclivity = ({ ctx, width, height, store }: DrawFunctionParams)
   const { slopes, ratioX, leftOffset } = store;
 
   const { maxGradient } = slopesValues(store);
-  const maxPosition = maxPositionValue(store);
+  const maxPosition = maxPositionValue(store.speeds);
 
   if (!slopes || slopes.length === 0) {
     console.error('Slopes data is missing or empty.');

--- a/ui-speedspacechart/src/components/helpers/drawElements/electricalProfile.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/electricalProfile.ts
@@ -25,7 +25,7 @@ export const drawElectricalProfile = ({ ctx, width, height, store }: DrawFunctio
 
   ctx.save();
   ctx.translate(leftOffset, 0);
-  const maxPosition = maxPositionValue(store);
+  const maxPosition = maxPositionValue(store.speeds);
   const {
     MARGIN_TOP,
     MARGIN_BOTTOM,

--- a/ui-speedspacechart/src/components/helpers/drawElements/powerRestrictions.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/powerRestrictions.ts
@@ -42,7 +42,7 @@ export const drawPowerRestrictions = ({
   ctx.save();
   ctx.translate(leftOffset, 0);
 
-  const maxPosition = maxPositionValue(store);
+  const maxPosition = maxPositionValue(store.speeds);
 
   ctx.font = 'normal 12px IBM Plex Sans';
   ctx.fillStyle = 'rgb(121, 118, 113)';

--- a/ui-speedspacechart/src/components/helpers/drawElements/reticle.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/reticle.ts
@@ -53,8 +53,8 @@ export const drawCursor = ({ ctx, width, height, store }: DrawFunctionParams) =>
   let modeText = '';
   let reticleY = 0;
 
-  const maxSpeed = maxSpeedValue(store);
-  const maxPosition = maxPositionValue(store);
+  const maxSpeed = maxSpeedValue(store.speeds);
+  const maxPosition = maxPositionValue(store.speeds);
 
   const heightWithoutLayers = getAdaptiveHeight(height, layersDisplay, false);
   const cursorBoxHeight = heightWithoutLayers - MARGIN_BOTTOM - MARGIN_TOP;

--- a/ui-speedspacechart/src/components/helpers/drawElements/speedLimitTags.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/speedLimitTags.ts
@@ -1,10 +1,15 @@
-import type { DrawFunctionParams, tooltipInfos } from '../../../types/chartTypes';
+import type {
+  DrawFunctionParams,
+  SpeedLimitTagsLayerDrawFunctionParams,
+  tooltipInfos,
+} from '../../../types/chartTypes';
 import {
   COLOR_DICTIONARY,
   LINEAR_LAYER_SEPARATOR_HEIGHT,
   LINEAR_LAYERS_BACKGROUND_COLOR,
   LINEAR_LAYERS_HEIGHTS,
   MARGINS,
+  WHITE,
 } from '../../const';
 import {
   clearCanvas,
@@ -43,23 +48,22 @@ export const drawSpeedLimitTags = async ({
   width,
   height: marginTop,
   store,
-}: DrawFunctionParams): Promise<tooltipInfos | null> => {
+}: SpeedLimitTagsLayerDrawFunctionParams) => {
   const {
     speedLimitTags,
     ratioX,
     leftOffset,
     layersDisplay: { electricalProfiles, powerRestrictions },
-    cursor,
   } = store;
 
-  const { MARGIN_TOP, MARGIN_BOTTOM, MARGIN_LEFT, MARGIN_RIGHT } = MARGINS;
+  const { MARGIN_BOTTOM, MARGIN_LEFT, MARGIN_RIGHT } = MARGINS;
 
   clearCanvas(ctx, width, LINEAR_LAYERS_HEIGHTS.SPEED_LIMIT_TAGS_HEIGHT);
 
   ctx.save();
   ctx.translate(leftOffset, 0);
 
-  const maxPosition = maxPositionValue(store);
+  const maxPosition = maxPositionValue(store.speeds);
 
   const questionImage = await loadSvgImage(questionBlobUrl);
   const alertFillImage = await loadSvgImage(alertFillBlobUrl);
@@ -82,108 +86,132 @@ export const drawSpeedLimitTags = async ({
     LINEAR_LAYERS_HEIGHTS.SPEED_LIMIT_TAGS_HEIGHT - LINEAR_LAYER_SEPARATOR_HEIGHT
   );
 
-  let tooltip: tooltipInfos | null = null;
+  if (!speedLimitTags) return;
 
-  if (speedLimitTags) {
-    speedLimitTags.forEach(({ position, value }, index) => {
-      const { tag, color } = value;
-      const x = positionOnGraphScale(position.start, maxPosition, width, ratioX, MARGINS);
-      const nextBoundary = positionOnGraphScale(position.end!, maxPosition, width, ratioX, MARGINS);
+  speedLimitTags.forEach(({ position, value }, index) => {
+    const { tag, color } = value;
+    const x = positionOnGraphScale(position.start, maxPosition, width, ratioX, MARGINS);
+    const nextBoundary = positionOnGraphScale(position.end!, maxPosition, width, ratioX, MARGINS);
 
-      if (nextBoundary !== undefined) {
-        const tagWidth = nextBoundary - x - RECTANGLE_SPACING;
+    if (nextBoundary !== undefined) {
+      const tagWidth = nextBoundary - x - RECTANGLE_SPACING;
 
-        const secondaryColor = COLOR_DICTIONARY[color] || color;
+      const secondaryColor = COLOR_DICTIONARY[color] || color;
+
+      ctx.fillStyle = color;
+      ctx.strokeStyle = tag === 'UU' ? '#494641' : color;
+      ctx.lineWidth = 1;
+
+      ctx.beginPath();
+      ctx.fillRect(x, Y_POSITION, tagWidth - RECTANGLE_SPACING, RECT_HEIGHT);
+
+      ctx.fillStyle = secondaryColor;
+
+      const textWidth =
+        ctx.measureText(tag).width +
+        TEXT_RIGHT_PADDING +
+        (index === 0 ? FIRST_TAG_LEFT_PADDING : 0);
+
+      ctx.fillRect(x + 1 + textWidth, Y_POSITION, tagWidth - textWidth - 2, RECT_HEIGHT);
+      ctx.rect(x + textWidth, Y_POSITION, tagWidth - RECTANGLE_SPACING - textWidth, RECT_HEIGHT);
+      ctx.strokeRect(x + 1, Y_POSITION, tagWidth - RECTANGLE_SPACING, RECT_HEIGHT);
+      ctx.closePath();
+
+      if (tag === 'UU') {
+        ctx.lineWidth = 0.5;
+        ctx.beginPath();
+        ctx.moveTo(x + textWidth + 2, Y_POSITION);
+        ctx.lineTo(x + textWidth + 2, Y_POSITION + RECT_HEIGHT);
+        ctx.closePath();
+        ctx.stroke();
+      }
+
+      if (tag === 'incompatible' || tag === 'missing_from_train') {
+        const image = tag === 'incompatible' ? alertFillImage : questionImage;
 
         ctx.fillStyle = color;
-        ctx.strokeStyle = tag === 'UU' ? '#494641' : color;
-        ctx.lineWidth = 1;
 
-        ctx.beginPath();
-        ctx.fillRect(x, Y_POSITION, tagWidth - RECTANGLE_SPACING, RECT_HEIGHT);
+        const iconXPosition = x + (tagWidth - ICON_BACKGROUND_WIDTH) / 2;
+        const iconYPosition = Y_POSITION - ICON_OFFSET;
+        const cornerRadius = 4;
 
-        ctx.fillStyle = secondaryColor;
+        drawRoundedRect(
+          ctx,
+          iconXPosition,
+          iconYPosition,
+          ICON_BACKGROUND_WIDTH,
+          ICON_BACKGROUND_HEIGHT,
+          cornerRadius
+        );
 
-        const textWidth =
-          ctx.measureText(tag).width +
-          TEXT_RIGHT_PADDING +
-          (index === 0 ? FIRST_TAG_LEFT_PADDING : 0);
-
-        ctx.fillRect(x + 1 + textWidth, Y_POSITION, tagWidth - textWidth - 2, RECT_HEIGHT);
-        ctx.rect(x + textWidth, Y_POSITION, tagWidth - RECTANGLE_SPACING - textWidth, RECT_HEIGHT);
-        ctx.strokeRect(x + 1, Y_POSITION, tagWidth - RECTANGLE_SPACING, RECT_HEIGHT);
-        ctx.closePath();
-
-        if (tag === 'UU') {
-          ctx.lineWidth = 0.5;
-          ctx.beginPath();
-          ctx.moveTo(x + textWidth + 2, Y_POSITION);
-          ctx.lineTo(x + textWidth + 2, Y_POSITION + RECT_HEIGHT);
-          ctx.closePath();
-          ctx.stroke();
-        }
-
-        if (tag === 'incompatible' || tag === 'missing_from_train') {
-          const image = tag === 'incompatible' ? alertFillImage : questionImage;
-
-          ctx.fillStyle = color;
-
-          const iconXPosition = x + (tagWidth - ICON_BACKGROUND_WIDTH) / 2;
-          const iconYPosition = Y_POSITION - ICON_OFFSET;
-          const cornerRadius = 4;
-
-          drawRoundedRect(
-            ctx,
-            iconXPosition,
-            iconYPosition,
-            ICON_BACKGROUND_WIDTH,
-            ICON_BACKGROUND_HEIGHT,
-            cornerRadius
-          );
-
-          drawSvgImageWithColor(
-            ctx,
-            image,
-            iconXPosition + ICON_OFFSET,
-            iconYPosition + ICON_OFFSET,
-            ICON_WIDTH,
-            ICON_HEIGHT,
-            '#FFFFFF'
-          );
-
-          if (tag === 'incompatible' && cursor.x && cursor.y) {
-            if (
-              cursor.x >= x - MARGIN_LEFT + leftOffset &&
-              cursor.x <= x - MARGIN_LEFT + leftOffset + tagWidth &&
-              cursor.y >= marginTop - MARGIN_TOP + Y_POSITION - 2 &&
-              cursor.y <= marginTop - MARGIN_TOP + Y_POSITION - 1 + RECT_HEIGHT
-            ) {
-              tooltip = {
-                cursorX: cursor.x + MARGIN_LEFT,
-                cursorY: Y_POSITION,
-                text: 'Incompatible with the infrastructure',
-              };
-            }
-          }
-        } else {
-          ctx.fillStyle = 'white';
-          ctx.font = '600 12px "IBM Plex Sans"';
-          ctx.textAlign = 'left';
-          ctx.textBaseline = 'middle';
-          const textPosition = x + TEXT_LEFT_PADDING;
-          ctx.fillText(tag, textPosition, Y_POSITION + TEXT_PADDING_TOP + RECT_HEIGHT / 2);
-        }
+        drawSvgImageWithColor(
+          ctx,
+          image,
+          iconXPosition + ICON_OFFSET,
+          iconYPosition + ICON_OFFSET,
+          ICON_WIDTH,
+          ICON_HEIGHT,
+          WHITE.hex()
+        );
+      } else {
+        ctx.fillStyle = 'white';
+        ctx.font = '600 12px "IBM Plex Sans"';
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'middle';
+        const textPosition = x + TEXT_LEFT_PADDING;
+        ctx.fillText(tag, textPosition, Y_POSITION + TEXT_PADDING_TOP + RECT_HEIGHT / 2);
       }
-    });
+    }
+  });
 
-    drawSeparatorLinearLayer(ctx, 'rgba(0,0,0,0.1)', MARGINS, width, marginTop);
-    ctx.restore();
+  drawSeparatorLinearLayer(ctx, 'rgba(0,0,0,0.1)', MARGINS, width, marginTop);
+  ctx.restore();
 
-    // prevent overlapping with margins left and right
-    ctx.clearRect(0, 0, MARGIN_LEFT, LINEAR_LAYERS_HEIGHTS.SPEED_LIMIT_TAGS_HEIGHT);
-    ctx.clearRect(width - MARGIN_RIGHT, 0, width, LINEAR_LAYERS_HEIGHTS.SPEED_LIMIT_TAGS_HEIGHT);
+  // prevent overlapping with margins left and right
+  ctx.clearRect(0, 0, MARGIN_LEFT, LINEAR_LAYERS_HEIGHTS.SPEED_LIMIT_TAGS_HEIGHT);
+  ctx.clearRect(width - MARGIN_RIGHT, 0, width, LINEAR_LAYERS_HEIGHTS.SPEED_LIMIT_TAGS_HEIGHT);
+};
 
-    return tooltip;
+export const computeTooltip = async ({
+  width,
+  height: marginTop,
+  store,
+}: DrawFunctionParams): Promise<tooltipInfos | null> => {
+  const { speedLimitTags, ratioX, leftOffset, cursor } = store;
+
+  const { MARGIN_TOP, MARGIN_LEFT } = MARGINS;
+
+  const maxPosition = maxPositionValue(store.speeds);
+
+  if (!speedLimitTags) return null;
+
+  for (const { position, value } of speedLimitTags) {
+    const tooltipTextMap: Record<string, string> = {
+      incompatible: 'Incompatible with the infrastructure',
+    };
+
+    const { tag } = value;
+    if (!(tag in tooltipTextMap)) continue;
+    const potentialTooltipText = tooltipTextMap[tag];
+
+    if (position.end === undefined || cursor.x === null || cursor.y === null) continue;
+
+    const x = positionOnGraphScale(position.start, maxPosition, width, ratioX, MARGINS);
+    const nextBoundary = positionOnGraphScale(position.end, maxPosition, width, ratioX, MARGINS);
+
+    const tagWidth = nextBoundary - x - RECTANGLE_SPACING;
+    if (
+      cursor.x >= x - MARGIN_LEFT + leftOffset &&
+      cursor.x <= x - MARGIN_LEFT + leftOffset + tagWidth &&
+      cursor.y >= marginTop - MARGIN_TOP + Y_POSITION - 2 &&
+      cursor.y <= marginTop - MARGIN_TOP + Y_POSITION - 1 + RECT_HEIGHT
+    ) {
+      return {
+        cursorX: cursor.x + MARGIN_LEFT,
+        cursorY: Y_POSITION,
+        text: potentialTooltipText,
+      };
+    }
   }
   return null;
 };

--- a/ui-speedspacechart/src/components/helpers/drawElements/speedLimits.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/speedLimits.ts
@@ -23,8 +23,8 @@ export const drawSpeedLimits = ({ ctx, width, height, store }: DrawFunctionParam
   ctx.translate(leftOffset, 0);
 
   const realHeight = height - MARGIN_BOTTOM - MARGIN_TOP;
-  const maxSpeed = maxSpeedValue(store);
-  const maxPosition = maxPositionValue(store);
+  const maxSpeed = maxSpeedValue(store.speeds);
+  const maxPosition = maxPositionValue(store.speeds);
 
   ctx.lineCap = 'round';
 

--- a/ui-speedspacechart/src/components/helpers/drawElements/steps.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/steps.ts
@@ -22,7 +22,7 @@ export const drawSteps = ({ ctx, width, height, store }: DrawFunctionParams) => 
 
   clearCanvas(ctx, width, height);
 
-  const maxPosition = maxPositionValue(store);
+  const maxPosition = maxPositionValue(store.speeds);
 
   const filteredStops = filterStops(stops, ratioX, width, maxPosition);
 

--- a/ui-speedspacechart/src/components/helpers/drawElements/tickX.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/tickX.ts
@@ -17,7 +17,7 @@ export const drawTickX = ({ ctx, width, height, store }: DrawFunctionParams) => 
   ctx.font = 'normal 12px IBM Plex Sans';
   ctx.fillStyle = 'rgb(182, 179, 175)';
 
-  const maxPosition = maxPositionValue(store);
+  const maxPosition = maxPositionValue(store.speeds);
   const windowLength = maxPosition / store.ratioX;
 
   // Define the tick scale and the principle tick frequency given the window length

--- a/ui-speedspacechart/src/components/layers/SpeedLimitTagsLayer.tsx
+++ b/ui-speedspacechart/src/components/layers/SpeedLimitTagsLayer.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef } from 'react';
 
-import { type Store, type tooltipInfos } from '../../types/chartTypes';
+import type { Store, tooltipInfos } from '../../types/chartTypes';
 import Tooltip from '../common/Tooltip';
 import { LINEAR_LAYERS_HEIGHTS } from '../const';
-import { drawSpeedLimitTags } from '../helpers/drawElements/speedLimitTags';
+import { drawSpeedLimitTags, computeTooltip } from '../helpers/drawElements/speedLimitTags';
 
 type SpeedLimitTagsLayerProps = {
   width: number;
@@ -18,12 +18,44 @@ const SpeedLimitTagsLayer = ({ width, marginTop, store }: SpeedLimitTagsLayerPro
   const tooltip = useRef<tooltipInfos | null>();
 
   useEffect(() => {
+    const updateCanvas = async () => {
+      const currentCanvas = canvas.current as HTMLCanvasElement;
+      const ctx = currentCanvas.getContext('2d') as CanvasRenderingContext2D;
+      const restrictedStore = {
+        speedLimitTags: store.speedLimitTags,
+        ratioX: store.ratioX,
+        leftOffset: store.leftOffset,
+        layersDisplay: {
+          electricalProfiles: store.layersDisplay.electricalProfiles,
+          powerRestrictions: store.layersDisplay.powerRestrictions,
+        },
+        speeds: store.speeds,
+      };
+      await drawSpeedLimitTags({
+        ctx,
+        width,
+        height: marginTop,
+        store: restrictedStore,
+      });
+    };
+    updateCanvas();
+  }, [
+    width,
+    marginTop,
+    store.speedLimitTags,
+    store.ratioX,
+    store.leftOffset,
+    store.layersDisplay.electricalProfiles,
+    store.layersDisplay.powerRestrictions,
+    store.speeds,
+  ]);
+
+  useEffect(() => {
     const updateTooltip = async () => {
       const currentCanvas = canvas.current as HTMLCanvasElement;
       const ctx = currentCanvas.getContext('2d') as CanvasRenderingContext2D;
-      tooltip.current = await drawSpeedLimitTags({ ctx, width, height: marginTop, store });
+      tooltip.current = await computeTooltip({ ctx, width, height: marginTop, store });
     };
-
     updateTooltip();
   }, [width, marginTop, store]);
 

--- a/ui-speedspacechart/src/components/utils.ts
+++ b/ui-speedspacechart/src/components/utils.ts
@@ -23,23 +23,20 @@ export const getGraphOffsets = (width: number, height: number, declivities?: boo
 
 /**
  * /**
- * Given a store including a list of speed data, return the maxSpeed
- * @param store
+ * Given a list of speed data, return the maxSpeed
+ * @param speeds
  */
-export const maxSpeedValue = (store: Store) => {
-  const speeds = store.speeds;
-  return Math.max(...speeds.map(({ value }) => value));
-};
-
+export const maxSpeedValue = (speeds: LayerData<number>[]) =>
+  Math.max(...speeds.map(({ value }) => value));
 /**
- * Given a store including a list of speed data return the max position
- * @param store
+ * Given a list of speed data return the max position
+ * @param speeds
  */
-export const maxPositionValue = (store: Store): number => {
-  if (store.speeds.length === 0) {
+export const maxPositionValue = (speeds: LayerData<number>[]): number => {
+  if (speeds.length === 0) {
     return 0.0;
   }
-  return store.speeds[store.speeds.length - 1].position.start;
+  return speeds[speeds.length - 1].position.start;
 };
 
 export const clearCanvas = (ctx: CanvasRenderingContext2D, width: number, height: number) => {
@@ -348,7 +345,7 @@ export const filterStops = (
 /** Compute the cursor position on the x-axis given its position on the canva */
 export const getCursorPosition = (cursorX: number, width: number, store: Store) => {
   const { ratioX, leftOffset } = store;
-  const maxPosition = maxPositionValue(store);
+  const maxPosition = maxPositionValue(store.speeds);
   const x = cursorX - leftOffset - MARGINS.CURVE_MARGIN_SIDES / 2;
   const maxX =
     (width - MARGINS.MARGIN_LEFT - MARGINS.MARGIN_RIGHT - MARGINS.CURVE_MARGIN_SIDES) * ratioX;
@@ -361,7 +358,7 @@ export const getCursorPosition = (cursorX: number, width: number, store: Store) 
  */
 export const getSnappedStop = (cursorX: number, width: number, store: Store) => {
   const { ratioX, leftOffset, stops } = store;
-  const maxPosition = maxPositionValue(store);
+  const maxPosition = maxPositionValue(store.speeds);
 
   // Search for the closest stop to the cursor
   const filteredStops = filterStops(stops, ratioX, width, maxPosition);

--- a/ui-speedspacechart/src/types/chartTypes.ts
+++ b/ui-speedspacechart/src/types/chartTypes.ts
@@ -93,6 +93,20 @@ export type DrawFunctionParams = {
   setStore?: React.Dispatch<React.SetStateAction<Store>>;
 };
 
+export type SpeedLimitTagsLayerDrawingStore = Pick<
+  Store,
+  'speedLimitTags' | 'ratioX' | 'leftOffset' | 'speeds'
+> & {
+  layersDisplay: Pick<Store['layersDisplay'], 'electricalProfiles' | 'powerRestrictions'>;
+};
+
+export type SpeedLimitTagsLayerDrawFunctionParams = {
+  ctx: CanvasRenderingContext2D;
+  width: number;
+  height: number;
+  store: SpeedLimitTagsLayerDrawingStore;
+};
+
 export type TrainDetails = {
   curveX: number;
   curveY: number;


### PR DESCRIPTION
Close #427

There were 2 issues I could find leading to the blinking : 
- the store object was used as a dependency of useEffect, which means it was triggered every time
- the tooltip computation and the canvas drawing were tied together in a single function, despite the tooltip computation depending on the cursor position (and we don't want the canvas to be redrawn whenever the cursor moves)

There seems to be an overreliance on the store object in the code, but it may take a major refactor to fix it.