### PR TITLE
ui-spacetimechart: use local timezone to format time

### DIFF
--- a/ui-spacetimechart/src/components/TimeCaptions.tsx
+++ b/ui-spacetimechart/src/components/TimeCaptions.tsx
@@ -8,11 +8,11 @@ const MINUTES_FORMATTER = (t: number) => `:${new Date(t).getMinutes().toString()
 const HOURS_FORMATTER = (t: number, pixelsPerMinute: number) => {
   const date = new Date(t);
   if (pixelsPerMinute > 1) {
-    const hours = date.getUTCHours().toString().padStart(2, '0');
+    const hours = date.getHours().toString().padStart(2, '0');
     const minutes = date.getMinutes().toString().padStart(2, '0');
     return `${hours}:${minutes}`;
   } else {
-    return date.getUTCHours().toString().padStart(2, '0');
+    return date.getHours().toString().padStart(2, '0');
   }
 };
 


### PR DESCRIPTION
First, the logic was inconsistent: UTC was used for hours but the local timezone was used for minutes. This works by chance because most timezones are 1h apart, however that's not true in general (e.g. Sri Lanka has +05:30 and Australia has +09:30).

Second, we never want to display UTC to the user. Users are always interested in times given in their timezone.