### PR TITLE
ui-spacetimechart: use paths layer for conflicts

### DIFF
--- a/ui-spacetimechart/src/components/ConflictLayer.tsx
+++ b/ui-spacetimechart/src/components/ConflictLayer.tsx
@@ -45,7 +45,7 @@ export const ConflictLayer = ({ conflicts }: ConflictLayerProps) => {
     [conflicts]
   );
 
-  useDraw('overlay', drawConflictLayer);
+  useDraw('paths', drawConflictLayer);
 
   return null;
 };


### PR DESCRIPTION
The overlay layer is rendered on top of the captions, which is undesirable here.

Example bug:

![out](https://github.com/user-attachments/assets/2726cb6d-d020-4538-9927-7c4ca5795b1e)
