### PR TITLE
ui-manchette-with-spacetimechart: fix op display

### DIFF
--- a/ui-manchette-with-spacetimechart/src/helpers.ts
+++ b/ui-manchette-with-spacetimechart/src/helpers.ts
@@ -34,12 +34,11 @@ export const calcOperationalPointsToDisplay = (
     const op = operationalPoints[i];
     const diff = op.position - lastDisplayedOP.position;
     const display = (diff / totalDistance) * heightWithoutFinalOp * yZoom >= BASE_OP_HEIGHT;
-    result.push({
-      ...op,
-      display,
-    });
 
-    if (display) lastDisplayedOP = result[i];
+    if (display) {
+      result.push({ ...op, display });
+      lastDisplayedOP = op;
+    }
   }
 
   // In the end, to make sure the last point is visible, if it's not, we swap

--- a/ui-manchette-with-spacetimechart/src/stories/base.stories.tsx
+++ b/ui-manchette-with-spacetimechart/src/stories/base.stories.tsx
@@ -51,7 +51,7 @@ const ManchetteWithSpaceTimeWrapper = ({
         <Manchette {...manchetteProps} />
         <div
           className="space-time-chart-container w-full sticky"
-          style={{ bottom: 0, left: 0, top: 0, height: `${DEFAULT_HEIGHT - 6}px` }}
+          style={{ bottom: 0, left: 0, top: 2, height: `${DEFAULT_HEIGHT - 6}px` }}
         >
           <SpaceTimeChart
             className="inset-0 absolute h-full"

--- a/ui-manchette-with-spacetimechart/src/styles/manchette.css
+++ b/ui-manchette-with-spacetimechart/src/styles/manchette.css
@@ -15,6 +15,7 @@
   .space-time-chart-container {
     height: 561px;
     width: 100%;
+    padding-top: 10px;
     bottom: 0;
   }
 }

--- a/ui-manchette/src/styles/operational-point-list.css
+++ b/ui-manchette/src/styles/operational-point-list.css
@@ -4,4 +4,12 @@
   padding-inline: 0.5rem 1.625rem;
 
   @apply bg-ambientB-10;
+
+  .operational-point-wrapper:last-child {
+    .op {
+      &::after {
+        bottom: 16px;
+      }
+    }
+  }
 }

--- a/ui-manchette/src/styles/operational-point.css
+++ b/ui-manchette/src/styles/operational-point.css
@@ -1,5 +1,8 @@
 .op {
   @apply text-grey-80;
+  height: 2rem;
+  line-height: 1.5rem;
+  padding-block: 3px 5px;
   width: 315px;
   position: relative;
   &-separator {
@@ -13,7 +16,7 @@
     &::after {
       content: '';
       position: absolute;
-      bottom: 10.75px;
+      bottom: 11px;
       left: 0;
       width: 100%;
       height: 0.5px;
@@ -82,7 +85,7 @@
     content: '';
     position: absolute;
     display: inline-block;
-    bottom: 10.75px;
+    bottom: 16px;
     right: -1.625rem;
     width: 1.625rem;
     height: 0.5px;


### PR DESCRIPTION
- set only displayable operational points in calcOperationalPointsToDisplay in helpers.ts
- add padding-top to operational-point-list

<img width="1080" alt="Capture d’écran 2024-10-21 à 14 20 07" src="https://github.com/user-attachments/assets/e02f3901-0b46-46be-90b3-4ca621e362d0">


close https://github.com/OpenRailAssociation/osrd/issues/8930
close #654 