### PR TITLE
ui-spacetimechart: handles better empty data

### DIFF
--- a/ui-spacetimechart/src/components/PathLayer.tsx
+++ b/ui-spacetimechart/src/components/PathLayer.tsx
@@ -271,6 +271,8 @@ export const PathLayer = ({
    */
   const drawExtremities = useCallback<DrawingFunction>(
     (ctx, { getTimePixel, getSpacePixel, swapAxis }) => {
+      if (!path.points.length) return;
+
       const pathDirection = getDirection(path);
       const from = path.points[0];
       const fromEnd = path.fromEnd || DEFAULT_PATH_END;

--- a/ui-spacetimechart/src/stories/base-rendering.stories.tsx
+++ b/ui-spacetimechart/src/stories/base-rendering.stories.tsx
@@ -14,33 +14,58 @@ type WrapperProps = {
   xOffset: number;
   yOffset: number;
   spaceScaleType: 'linear' | 'proportional';
+  emptyData: boolean;
 };
 
 /**
  * This story aims at showcasing how to render a SpaceTimeChart.
  */
-const Wrapper = ({ xZoomLevel, yZoomLevel, xOffset, yOffset, spaceScaleType }: WrapperProps) => (
-  <SpaceTimeChart
-    className="inset-0 absolute"
-    operationalPoints={OPERATIONAL_POINTS}
-    spaceOrigin={0}
-    spaceScales={OPERATIONAL_POINTS.slice(0, -1).map((point, i) => ({
-      from: point.position,
-      to: OPERATIONAL_POINTS[i + 1].position,
-      ...(spaceScaleType === 'linear'
-        ? { size: 50 * yZoomLevel }
-        : { coefficient: 150 / yZoomLevel }),
-    }))}
-    timeOrigin={+new Date('2024/04/02')}
-    timeScale={60000 / xZoomLevel}
-    xOffset={xOffset}
-    yOffset={yOffset}
-  >
-    {PATHS.map((path) => (
-      <PathLayer key={path.id} path={path} color={path.color} />
-    ))}
-  </SpaceTimeChart>
-);
+const Wrapper = ({
+  xZoomLevel,
+  yZoomLevel,
+  xOffset,
+  yOffset,
+  spaceScaleType,
+  emptyData,
+}: WrapperProps) => {
+  const operationalPoints = emptyData ? [] : OPERATIONAL_POINTS;
+  const spaceScales = emptyData
+    ? []
+    : OPERATIONAL_POINTS.slice(0, -1).map((point, i) => ({
+        from: point.position,
+        to: OPERATIONAL_POINTS[i + 1].position,
+        ...(spaceScaleType === 'linear'
+          ? { size: 50 * yZoomLevel }
+          : { coefficient: 150 / yZoomLevel }),
+      }));
+  const paths = emptyData
+    ? [
+        {
+          id: `empty-train`,
+          label: `Train with no path`,
+          color: 'transparent',
+          points: [],
+        },
+      ]
+    : PATHS;
+
+  return (
+    <SpaceTimeChart
+      className="inset-0 absolute"
+      operationalPoints={operationalPoints}
+      spaceOrigin={0}
+      spaceScales={spaceScales}
+      timeOrigin={+new Date('2024/04/02')}
+      timeScale={60000 / xZoomLevel}
+      xOffset={xOffset}
+      yOffset={yOffset}
+    >
+      {paths.map((path) => (
+        <PathLayer key={path.id} path={path} color={path.color} />
+      ))}
+    </SpaceTimeChart>
+  );
+};
 
 export default {
   title: 'SpaceTimeChart/Rendering',
@@ -76,6 +101,11 @@ export default {
       defaultValue: 'linear',
       control: { type: 'radio' },
     },
+    emptyData: {
+      name: 'Use empty data',
+      defaultValue: false,
+      control: { type: 'boolean' },
+    },
   },
 } as Meta<typeof Wrapper>;
 
@@ -87,5 +117,6 @@ export const DefaultArgs = {
     xOffset: 0,
     yOffset: 0,
     spaceScaleType: 'linear',
+    emptyData: false,
   },
 };

--- a/ui-spacetimechart/src/utils/scales.ts
+++ b/ui-spacetimechart/src/utils/scales.ts
@@ -72,7 +72,13 @@ export function spaceScalesToBinaryTree(
   // Step 3: Build the tree
   function buildTree(scales: NormalizedScale[]): NormalizedScaleTree {
     if (scales.length === 0) {
-      throw new Error('Invalid scales: there should be at least one scale.');
+      return {
+        coefficient: 1,
+        from: -Infinity,
+        to: Infinity,
+        pixelFrom: -Infinity,
+        pixelTo: Infinity,
+      };
     } else if (scales.length === 1) {
       return scales[0];
     } else {


### PR DESCRIPTION
This commit fixes #648.

Details:
- Adds a new "Use empty data" in the SpaceTimeChart/Rendering story, to use no OP, no scales and only a path with no point, as data
- Removes the "Invalid scales" error, and replaces it by generating a dummy placeholder NormalizedScaleTree
- In PathLayer.tsx, handles the only case where it's actually mandatory to have some point, with an early exit