### PR TITLE
github: group typescript-eslint upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
       turf:
         patterns:
           - "@turf/*"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
     commit-message:
       prefix: "dependency:"
     open-pull-requests-limit: 100


### PR DESCRIPTION
Otherwise dependabot gets confused and tries to upgrade only one of these dependencies, which fails:
https://github.com/OpenRailAssociation/osrd-ui/pull/656