### PR TITLE
dependency: bump eslint-plugin-import to 2.31.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3076,6 +3076,13 @@
         "win32"
       ]
     },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sigstore/bundle": {
       "version": "2.3.2",
       "dev": true,
@@ -8387,7 +8394,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.8.1",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
+      "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8404,6 +8413,8 @@
     },
     "node_modules/eslint-module-utils/node_modules/debug": {
       "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8411,33 +8422,37 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.29.1",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
+      "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "array-includes": "^3.1.7",
-        "array.prototype.findlastindex": "^1.2.3",
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.8",
+        "array.prototype.findlastindex": "^1.2.5",
         "array.prototype.flat": "^1.3.2",
         "array.prototype.flatmap": "^1.3.2",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.8.0",
-        "hasown": "^2.0.0",
-        "is-core-module": "^2.13.1",
+        "eslint-module-utils": "^2.12.0",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.15.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.7",
-        "object.groupby": "^1.0.1",
-        "object.values": "^1.1.7",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.0",
         "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.8",
         "tsconfig-paths": "^3.15.0"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
@@ -10530,7 +10545,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.0",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"

--- a/ui-spacetimechart/src/stories/additional-data.stories.tsx
+++ b/ui-spacetimechart/src/stories/additional-data.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta } from '@storybook/react';
 import cx from 'classnames';
 import { clamp, inRange } from 'lodash';
 
+import { SpaceTimeChart, PathLayer } from '../';
 import { MouseTracker } from './lib/components';
 import { OPERATIONAL_POINTS, PATHS, START_DATE } from './lib/paths';
 import {
@@ -14,7 +15,6 @@ import {
   X_ZOOM_LEVEL,
   Y_ZOOM_LEVEL,
 } from './lib/utils';
-import { SpaceTimeChart, PathLayer } from '../';
 import { useDraw } from '../hooks/useCanvas';
 import { AMBIANT_A10, ERROR_30, ERROR_60, HOUR, KILOMETER, MINUTE } from '../lib/consts';
 import { type DrawingFunction, type Point } from '../lib/types';

--- a/ui-spacetimechart/src/stories/base-rendering.stories.tsx
+++ b/ui-spacetimechart/src/stories/base-rendering.stories.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import type { Meta } from '@storybook/react';
 
+import { SpaceTimeChart, PathLayer } from '../';
 import { OPERATIONAL_POINTS, PATHS } from './lib/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL } from './lib/utils';
-import { SpaceTimeChart, PathLayer } from '../';
 
 import '@osrd-project/ui-spacetimechart/dist/theme.css';
 

--- a/ui-spacetimechart/src/stories/custom-styles.stories.tsx
+++ b/ui-spacetimechart/src/stories/custom-styles.stories.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import type { Meta } from '@storybook/react';
 import cx from 'classnames';
 
+import { PathLayer, SpaceTimeChart } from '../';
 import { OPERATIONAL_POINTS, PATHS } from './lib/paths';
 import {
   MAX_X_ZOOM,
@@ -12,7 +13,6 @@ import {
   X_ZOOM_LEVEL,
   Y_ZOOM_LEVEL,
 } from './lib/utils';
-import { PathLayer, SpaceTimeChart } from '../';
 import { type Point } from '../lib/types';
 import { getDiff } from '../utils/vectors';
 

--- a/ui-spacetimechart/src/stories/layers.stories.tsx
+++ b/ui-spacetimechart/src/stories/layers.stories.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { ConflictLayer, OccupancyBlockLayer, SpaceTimeChart, PathLayer } from '../';
 import { OPERATIONAL_POINTS, PATHS, START_DATE } from './lib/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL } from './lib/utils';
-import { ConflictLayer, OccupancyBlockLayer, SpaceTimeChart, PathLayer } from '../';
 import {
   KILOMETER,
   MINUTE,

--- a/ui-spacetimechart/src/stories/measuring.stories.tsx
+++ b/ui-spacetimechart/src/stories/measuring.stories.tsx
@@ -3,10 +3,10 @@ import React, { useState } from 'react';
 import type { Meta } from '@storybook/react';
 import cx from 'classnames';
 
+import { SpaceTimeChart, PathLayer } from '../';
 import { MouseTracker } from './lib/components';
 import { OPERATIONAL_POINTS, PATHS } from './lib/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom } from './lib/utils';
-import { SpaceTimeChart, PathLayer } from '../';
 import { type DataPoint, type Point } from '../lib/types';
 import { getDiff } from '../utils/vectors';
 

--- a/ui-spacetimechart/src/stories/options.stories.tsx
+++ b/ui-spacetimechart/src/stories/options.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta } from '@storybook/react';
 import cx from 'classnames';
 import FileSaver from 'file-saver';
 
+import { SpaceTimeChart, PathLayer } from '../';
 import { MouseTracker } from './lib/components';
 import { OPERATIONAL_POINTS, PATHS } from './lib/paths';
 import {
@@ -14,7 +15,6 @@ import {
   X_ZOOM_LEVEL,
   Y_ZOOM_LEVEL,
 } from './lib/utils';
-import { SpaceTimeChart, PathLayer } from '../';
 import { CanvasContext } from '../lib/context';
 import { type Point } from '../lib/types';
 import { getDiff } from '../utils/vectors';

--- a/ui-spacetimechart/src/stories/paths-interactions.stories.tsx
+++ b/ui-spacetimechart/src/stories/paths-interactions.stories.tsx
@@ -4,9 +4,9 @@ import type { Meta } from '@storybook/react';
 import cx from 'classnames';
 import { keyBy } from 'lodash';
 
+import { SpaceTimeChart, PathLayer } from '../';
 import { OPERATIONAL_POINTS, PATHS } from './lib/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom } from './lib/utils';
-import { SpaceTimeChart, PathLayer } from '../';
 import { type HoveredItem, type PathData, type Point } from '../lib/types';
 import { getDiff } from '../utils/vectors';
 

--- a/ui-spacetimechart/src/stories/performances.stories.tsx
+++ b/ui-spacetimechart/src/stories/performances.stories.tsx
@@ -4,9 +4,9 @@ import { type Meta } from '@storybook/react';
 import cx from 'classnames';
 import { random, range } from 'lodash';
 
+import { SpaceTimeChart, PathLayer } from '../';
 import { getPaths, type PATHS } from './lib/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom } from './lib/utils';
-import { SpaceTimeChart, PathLayer } from '../';
 import { KILOMETER, MINUTE } from '../lib/consts';
 import { type OperationalPoint, type Point } from '../lib/types';
 import { getDiff } from '../utils/vectors';

--- a/ui-spacetimechart/src/stories/scroll-navigation.stories.tsx
+++ b/ui-spacetimechart/src/stories/scroll-navigation.stories.tsx
@@ -4,9 +4,9 @@ import type { Meta } from '@storybook/react';
 import cx from 'classnames';
 import { keyBy } from 'lodash';
 
+import { SpaceTimeChart, PathLayer } from '../';
 import { OPERATIONAL_POINTS, PATHS } from './lib/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom } from './lib/utils';
-import { SpaceTimeChart, PathLayer } from '../';
 import { type HoveredItem, type Point } from '../lib/types';
 import { isPathOnScreen } from '../utils/geometry';
 import { getSpaceAtTime } from '../utils/scales';

--- a/ui-spacetimechart/src/stories/stage-interactions.stories.tsx
+++ b/ui-spacetimechart/src/stories/stage-interactions.stories.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import type { Meta } from '@storybook/react';
 import cx from 'classnames';
 
+import { SpaceTimeChart, PathLayer } from '../';
 import { OPERATIONAL_POINTS, PATHS } from './lib/paths';
 import {
   MAX_X_ZOOM,
@@ -12,7 +13,6 @@ import {
   X_ZOOM_LEVEL,
   Y_ZOOM_LEVEL,
 } from './lib/utils';
-import { SpaceTimeChart, PathLayer } from '../';
 import { type Point } from '../lib/types';
 import { getDiff } from '../utils/vectors';
 


### PR DESCRIPTION
This requires manual changes because '..' is now sorted before other imports.