### PR TITLE
ui-speedspacechart: update tooltip correctly

### DIFF
--- a/ui-speedspacechart/src/components/layers/ReticleLayer.tsx
+++ b/ui-speedspacechart/src/components/layers/ReticleLayer.tsx
@@ -14,7 +14,6 @@ type ReticleLayerProps = {
 
 const ReticleLayer = ({ width, height, heightOffset, store }: ReticleLayerProps) => {
   const canvas = useRef<HTMLCanvasElement>(null);
-  const detailsBox = useRef<TrainDetails>();
   const [trainDetails, setTrainDetails] = useState<TrainDetails | null>(null);
   const maxCursorHeight = getAdaptiveHeight(heightOffset, store.layersDisplay, false);
 
@@ -23,14 +22,10 @@ const ReticleLayer = ({ width, height, heightOffset, store }: ReticleLayerProps)
     const ctx = currentCanvas.getContext('2d') as CanvasRenderingContext2D;
     // The tooltip shouldn't be displayed when hovering on the linear layers
     if (store.cursor.y && store.cursor.y < maxCursorHeight) {
-      detailsBox.current = drawCursor({ ctx, width, height, store });
+      const detailsBox = drawCursor({ ctx, width, height, store });
+      setTrainDetails(detailsBox || null);
     }
   }, [width, height, store, maxCursorHeight]);
-
-  useEffect(() => {
-    setTrainDetails(detailsBox.current!);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [detailsBox.current]);
 
   return (
     <>


### PR DESCRIPTION
closes [#9466](https://github.com/OpenRailAssociation/osrd/issues/9466)