### PR TITLE
ui-speedspacechart: use specific d3 sub-packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4675,6 +4675,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chroma-js": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.4.4.tgz",
+      "integrity": "sha512-/DTccpHTaKomqussrn+ciEvfW4k6NAHzNzs/sts1TCqg333qNxOhy8TNIoQCmbGG3Tl8KdEhkGAssb1n3mTXiQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -18503,10 +18509,6 @@
         "tailwindcss": ">=3.4"
       }
     },
-    "ui-spacetimechart/node_modules/@types/chroma-js": {
-      "version": "2.4.4",
-      "license": "MIT"
-    },
     "ui-speedspacechart": {
       "name": "@osrd-project/ui-speedspacechart",
       "version": "0.0.1-dev",
@@ -18514,6 +18516,7 @@
       "dependencies": {
         "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
+        "@types/chroma-js": "^2.4.4",
         "@types/d3": "^7.4.3",
         "chroma-js": "^3.1.1",
         "classnames": "^2.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4690,123 +4690,8 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/d3": {
-      "version": "7.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-array": "*",
-        "@types/d3-axis": "*",
-        "@types/d3-brush": "*",
-        "@types/d3-chord": "*",
-        "@types/d3-color": "*",
-        "@types/d3-contour": "*",
-        "@types/d3-delaunay": "*",
-        "@types/d3-dispatch": "*",
-        "@types/d3-drag": "*",
-        "@types/d3-dsv": "*",
-        "@types/d3-ease": "*",
-        "@types/d3-fetch": "*",
-        "@types/d3-force": "*",
-        "@types/d3-format": "*",
-        "@types/d3-geo": "*",
-        "@types/d3-hierarchy": "*",
-        "@types/d3-interpolate": "*",
-        "@types/d3-path": "*",
-        "@types/d3-polygon": "*",
-        "@types/d3-quadtree": "*",
-        "@types/d3-random": "*",
-        "@types/d3-scale": "*",
-        "@types/d3-scale-chromatic": "*",
-        "@types/d3-selection": "*",
-        "@types/d3-shape": "*",
-        "@types/d3-time": "*",
-        "@types/d3-time-format": "*",
-        "@types/d3-timer": "*",
-        "@types/d3-transition": "*",
-        "@types/d3-zoom": "*"
-      }
-    },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.1",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-axis": {
-      "version": "3.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-brush": {
-      "version": "3.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-chord": {
-      "version": "3.0.6",
-      "license": "MIT"
-    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-contour": {
-      "version": "3.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-array": "*",
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-delaunay": {
-      "version": "6.0.4",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-dispatch": {
-      "version": "3.0.6",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-drag": {
-      "version": "3.0.7",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-dsv": {
-      "version": "3.0.7",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-fetch": {
-      "version": "3.0.7",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-dsv": "*"
-      }
-    },
-    "node_modules/@types/d3-force": {
-      "version": "3.0.10",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-format": {
-      "version": "3.0.4",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-geo": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-hierarchy": {
-      "version": "3.1.7",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
@@ -4816,62 +4701,9 @@
         "@types/d3-color": "*"
       }
     },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.0",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-polygon": {
-      "version": "3.0.2",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-quadtree": {
-      "version": "3.0.6",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-random": {
-      "version": "3.0.3",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-scale-chromatic": {
-      "version": "3.0.3",
-      "license": "MIT"
-    },
     "node_modules/@types/d3-selection": {
       "version": "3.0.10",
       "license": "MIT"
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.3",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-time-format": {
-      "version": "4.0.3",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-transition": {
-      "version": "3.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
     },
     "node_modules/@types/d3-zoom": {
       "version": "3.0.8",
@@ -6741,6 +6573,7 @@
     },
     "node_modules/commander": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -7282,109 +7115,9 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/d3": {
-      "version": "7.9.0",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "3",
-        "d3-axis": "3",
-        "d3-brush": "3",
-        "d3-chord": "3",
-        "d3-color": "3",
-        "d3-contour": "4",
-        "d3-delaunay": "6",
-        "d3-dispatch": "3",
-        "d3-drag": "3",
-        "d3-dsv": "3",
-        "d3-ease": "3",
-        "d3-fetch": "3",
-        "d3-force": "3",
-        "d3-format": "3",
-        "d3-geo": "3",
-        "d3-hierarchy": "3",
-        "d3-interpolate": "3",
-        "d3-path": "3",
-        "d3-polygon": "3",
-        "d3-quadtree": "3",
-        "d3-random": "3",
-        "d3-scale": "4",
-        "d3-scale-chromatic": "3",
-        "d3-selection": "3",
-        "d3-shape": "3",
-        "d3-time": "3",
-        "d3-time-format": "4",
-        "d3-timer": "3",
-        "d3-transition": "3",
-        "d3-zoom": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-axis": {
-      "version": "3.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-brush": {
-      "version": "3.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "3",
-        "d3-transition": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-chord": {
-      "version": "3.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-contour": {
-      "version": "4.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-delaunay": {
-      "version": "6.0.4",
-      "license": "ISC",
-      "dependencies": {
-        "delaunator": "5"
-      },
       "engines": {
         "node": ">=12"
       }
@@ -7407,88 +7140,9 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-dsv": {
-      "version": "3.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "commander": "7",
-        "iconv-lite": "0.6",
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/dsv2json.js",
-        "csv2tsv": "bin/dsv2dsv.js",
-        "dsv2dsv": "bin/dsv2dsv.js",
-        "dsv2json": "bin/dsv2json.js",
-        "json2csv": "bin/json2dsv.js",
-        "json2dsv": "bin/json2dsv.js",
-        "json2tsv": "bin/json2dsv.js",
-        "tsv2csv": "bin/dsv2dsv.js",
-        "tsv2json": "bin/dsv2json.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dsv/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-fetch": {
-      "version": "3.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dsv": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-force": {
-      "version": "3.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-quadtree": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-geo": {
-      "version": "3.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.5.0 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-hierarchy": {
-      "version": "3.1.2",
-      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -7503,92 +7157,9 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-polygon": {
-      "version": "3.0.1",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-quadtree": {
-      "version": "3.0.1",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-random": {
-      "version": "3.0.1",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-interpolate": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
       "engines": {
         "node": ">=12"
       }
@@ -7863,13 +7434,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delaunator": {
-      "version": "5.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -10446,13 +10010,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -15960,6 +15517,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -18517,10 +18075,12 @@
         "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
         "@types/chroma-js": "^2.4.4",
-        "@types/d3": "^7.4.3",
+        "@types/d3-selection": "^3.0.0",
+        "@types/d3-zoom": "^3.0.0",
         "chroma-js": "^3.1.1",
         "classnames": "^2.5.1",
-        "d3": "^7.9.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
         "tailwindcss": "^3.4.1"
       },
       "devDependencies": {

--- a/ui-speedspacechart/package.json
+++ b/ui-speedspacechart/package.json
@@ -40,10 +40,12 @@
     "@osrd-project/ui-core": "0.0.1-dev",
     "@osrd-project/ui-icons": "0.0.1-dev",
     "@types/chroma-js": "^2.4.4",
-    "@types/d3": "^7.4.3",
+    "@types/d3-selection": "^3.0.0",
+    "@types/d3-zoom": "^3.0.0",
     "chroma-js": "^3.1.1",
     "classnames": "^2.5.1",
-    "d3": "^7.9.0",
+    "d3-selection": "^3.0.0",
+    "d3-zoom": "^3.0.0",
     "tailwindcss": "^3.4.1"
   },
   "peerDependencies": {

--- a/ui-speedspacechart/package.json
+++ b/ui-speedspacechart/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@osrd-project/ui-core": "0.0.1-dev",
     "@osrd-project/ui-icons": "0.0.1-dev",
+    "@types/chroma-js": "^2.4.4",
     "@types/d3": "^7.4.3",
     "chroma-js": "^3.1.1",
     "classnames": "^2.5.1",

--- a/ui-speedspacechart/src/components/helpers/frontFrame.ts
+++ b/ui-speedspacechart/src/components/helpers/frontFrame.ts
@@ -1,4 +1,4 @@
-import * as d3 from 'd3';
+import * as d3selection from 'd3-selection';
 
 import { zoom } from './layersManager';
 import type { DrawFunctionParams } from '../../types/chartTypes';
@@ -8,7 +8,7 @@ import { clearCanvas } from '../utils';
 export const drawFrame = ({ ctx, width, height, store, setStore }: DrawFunctionParams) => {
   clearCanvas(ctx, width, height);
 
-  const canvas = d3.select(FRONT_INTERACTIVITY_LAYER_ID) as d3.Selection<
+  const canvas = d3selection.select(FRONT_INTERACTIVITY_LAYER_ID) as d3selection.Selection<
     Element,
     unknown,
     HTMLCanvasElement,
@@ -20,7 +20,7 @@ export const drawFrame = ({ ctx, width, height, store, setStore }: DrawFunctionP
 
   // cursor interaction
   canvas.on('mousemove', (event) => {
-    const cursor = d3.pointer(event);
+    const cursor = d3selection.pointer(event);
 
     if (setStore) {
       setStore(() => ({

--- a/ui-speedspacechart/src/components/helpers/layersManager.ts
+++ b/ui-speedspacechart/src/components/helpers/layersManager.ts
@@ -1,24 +1,25 @@
-import * as d3 from 'd3';
+import * as d3selection from 'd3-selection';
+import * as d3zoom from 'd3-zoom';
 
 import type { Store } from '../../types/chartTypes';
 import { FRONT_INTERACTIVITY_LAYER_ID } from '../const';
 
 export const resetZoom = () =>
-  d3.zoom().transform(d3.select(FRONT_INTERACTIVITY_LAYER_ID), d3.zoomIdentity);
+  d3zoom.zoom().transform(d3selection.select(FRONT_INTERACTIVITY_LAYER_ID), d3zoom.zoomIdentity);
 
 export const zoom = (setStore: React.Dispatch<React.SetStateAction<Store>>) =>
-  d3
+  d3zoom
     .zoom()
     .filter((event) => event.shiftKey)
     .on('zoom', () => {
-      const canvas = d3.select(FRONT_INTERACTIVITY_LAYER_ID) as d3.Selection<
+      const canvas = d3selection.select(FRONT_INTERACTIVITY_LAYER_ID) as d3selection.Selection<
         Element,
         unknown,
         HTMLCanvasElement,
         unknown
       >;
 
-      const { k: ratioX, x: leftOffset } = d3.zoomTransform(canvas.node() as Element);
+      const { k: ratioX, x: leftOffset } = d3zoom.zoomTransform(canvas.node() as Element);
 
       if (ratioX >= 1) {
         setStore((prev) => ({

--- a/ui-speedspacechart/src/stories/utils.ts
+++ b/ui-speedspacechart/src/stories/utils.ts
@@ -44,7 +44,7 @@ const formatStops = (operationalPoints: PathProperties['operational_points']) =>
     position: {
       start: convertMmToKM(position),
     },
-    value: `${extensions.identifier.name} ${extensions.ch !== ('' || '00') ? extensions.ch : ''}`,
+    value: `${extensions.identifier.name} ${extensions.ch !== '00' ? extensions.ch : ''}`,
   }));
 
 const formatElectrifications = (electrifications: PathProperties['electrifications']) =>


### PR DESCRIPTION
_See individual commits._

Instead of importing all of d3, only import the two sub-packages
that we actually need: d3-selection and d3-zoom.

This removes 28 unused d3 sub-packages and all of their dependencies.