### PR TITLE
ui-core: remove hardcoded label size in checkbox and compensate with small right padding

### DIFF
--- a/ui-core/src/styles/inputs/checkbox.css
+++ b/ui-core/src/styles/inputs/checkbox.css
@@ -13,11 +13,12 @@
   font-weight: 400;
   letter-spacing: 0;
   text-align: left;
+  width: fit-content;
 
   .label {
     line-height: 1.5rem;
     padding-top: 0.188rem;
-    width: 12.813rem;
+    padding-right: 0.35rem;
     @apply text-grey-80;
   }
 


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/9463