### PR TITLE
ui-trackoccupancydiagram: setup sub-repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "ui-warped-map",
         "ui-manchette",
         "ui-manchette-with-spacetimechart",
+        "ui-trackoccupancydiagram",
         "storybook"
       ],
       "devDependencies": {
@@ -3023,6 +3024,10 @@
     },
     "node_modules/@osrd-project/ui-speedspacechart": {
       "resolved": "ui-speedspacechart",
+      "link": true
+    },
+    "node_modules/@osrd-project/ui-trackoccupancydiagram": {
+      "resolved": "ui-trackoccupancydiagram",
       "link": true
     },
     "node_modules/@osrd-project/ui-warped-map": {
@@ -17931,6 +17936,30 @@
         "classnames": "^2.5.1",
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0",
+        "tailwindcss": "^3.4.1"
+      },
+      "devDependencies": {
+        "autoprefixer": "^10.4.17",
+        "postcss": "^8.4.37",
+        "postcss-assets": "^6.0.0",
+        "postcss-import": "^16.0.0",
+        "postcss-preset-env": "^10.0.5",
+        "rollup-plugin-livereload": "^2.0.5",
+        "rollup-plugin-postcss": "^4.0.2",
+        "rollup-plugin-serve": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "ui-trackoccupancydiagram": {
+      "name": "@osrd-project/ui-trackoccupancydiagram",
+      "version": "0.0.1-dev",
+      "license": "LGPL-3.0-or-later",
+      "dependencies": {
+        "@types/chroma-js": "^2.4.4",
+        "chroma-js": "^3.1.1",
+        "classnames": "^2.5.1",
         "tailwindcss": "^3.4.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "ui-warped-map",
     "ui-manchette",
     "ui-manchette-with-spacetimechart",
+    "ui-trackoccupancydiagram",
     "storybook"
   ],
   "engines": {

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -5,9 +5,9 @@ import { mergeConfig } from 'vite';
 /** @type { import('@storybook/html-vite').StorybookConfig } */
 const config: StorybookConfig = {
   stories: [
-    '../stories/**/stories.ts',
-    '../../**/src/**/*.mdx',
+    // TODO: remove this when every stories are migrated to `@osrd-project/stroybook/stories/`
     '../../**/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+    '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)',
   ],
   addons: [
     getAbsolutePath('@storybook/addon-links'),

--- a/storybook/stories/TrackOccupancyDiagram/TrackOccupancyDiagram.stories.tsx
+++ b/storybook/stories/TrackOccupancyDiagram/TrackOccupancyDiagram.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import {
+  TrackOccupancyManchette,
+  TrackOccupancyCanvas,
+} from '../../../ui-trackoccupancydiagram/src/index';
+
+const TrackOccupancyDiagram = () => (
+  <div>
+    <TrackOccupancyManchette />
+    <TrackOccupancyCanvas />
+  </div>
+);
+
+const meta: Meta<typeof TrackOccupancyDiagram> = {
+  title: 'TrackOccupancyDiagram/Rendering',
+  component: TrackOccupancyDiagram,
+  decorators: [(Story) => <Story />],
+  parameters: {
+    layout: 'centered',
+    backgrounds: {
+      default: 'dark',
+    },
+  },
+  args: {},
+
+  render: () => <TrackOccupancyDiagram />,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TrackOccupancyDiagram>;
+
+export const TrackOccupancyDiagramStoryDefault: Story = {
+  args: {},
+};

--- a/storybook/stories/just-a-test.mdx
+++ b/storybook/stories/just-a-test.mdx
@@ -1,3 +1,0 @@
-import { Meta } from '@storybook/blocks';
-
-<Meta title="Just a test" />

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../tsconfig.base.json",
-  "include": [".storybook/*.tsx", "./stories/**/*"],
+  "include": [".storybook/*.tsx", "stories/**/*"],
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "../",
     "outDir": "./dist",
     "declarationDir": "./dist"
   }

--- a/ui-trackoccupancydiagram/package.json
+++ b/ui-trackoccupancydiagram/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@osrd-project/ui-trackoccupancydiagram",
+  "version": "0.0.1-dev",
+  "license": "LGPL-3.0-or-later",
+  "bugs": "https://github.com/osrd-project/osrd-ui/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/osrd-project/osrd-ui.git",
+    "directory": "ui-trackoccupancydiagram"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "module": "./dist/index.esm.js",
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.esm.js",
+  "style": "dist/theme.css",
+  "files": [
+    "/dist"
+  ],
+  "exports": {
+    "./dist/theme.css": "./dist/theme.css",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.esm.js"
+    }
+  },
+  "scripts": {
+    "rollup": "rollup -c",
+    "clean": "rimraf dist",
+    "build": "npm run rollup",
+    "watch": "NODE_ENV=development rollup -c -w",
+    "test": "vitest run --dir src/__tests__",
+    "prepublishOnly": "npm run clean && npm run build",
+    "lint": "eslint src --max-warnings 0",
+    "lint:fix": "eslint src --fix"
+  },
+  "dependencies": {
+    "@types/chroma-js": "^2.4.4",
+    "chroma-js": "^3.1.1",
+    "classnames": "^2.5.1",
+    "tailwindcss": "^3.4.1"
+  },
+  "peerDependencies": {
+    "react": ">=18.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.37",
+    "postcss-assets": "^6.0.0",
+    "postcss-import": "^16.0.0",
+    "postcss-preset-env": "^10.0.5",
+    "rollup-plugin-livereload": "^2.0.5",
+    "rollup-plugin-postcss": "^4.0.2",
+    "rollup-plugin-serve": "^1.1.1"
+  }
+}

--- a/ui-trackoccupancydiagram/rollup.config.js
+++ b/ui-trackoccupancydiagram/rollup.config.js
@@ -1,0 +1,3 @@
+import generateBaseRollupConfig from '../rollup-base.config.js';
+
+export default generateBaseRollupConfig('osrdTrackOccupancyDiagram', ['react']);

--- a/ui-trackoccupancydiagram/src/__tests__/utils.spec.ts
+++ b/ui-trackoccupancydiagram/src/__tests__/utils.spec.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from 'vitest';
+
+describe('test to remove', () => {
+  it('should return the good value', () => {
+    expect(1 + 1).toEqual(2);
+  });
+});

--- a/ui-trackoccupancydiagram/src/components/TrackOccupancyCanvas.tsx
+++ b/ui-trackoccupancydiagram/src/components/TrackOccupancyCanvas.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const TrackOccupancyCanvas = () => <div>TrackOccupancyCanvas</div>;
+
+export default TrackOccupancyCanvas;

--- a/ui-trackoccupancydiagram/src/components/TrackOccupancyManchette.tsx
+++ b/ui-trackoccupancydiagram/src/components/TrackOccupancyManchette.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const TrackOccupancyManchette = () => <div>TrackOccupancyManchette</div>;
+
+export default TrackOccupancyManchette;

--- a/ui-trackoccupancydiagram/src/index.ts
+++ b/ui-trackoccupancydiagram/src/index.ts
@@ -1,0 +1,5 @@
+import '@osrd-project/ui-core/dist/theme.css';
+import './styles/main.css';
+
+export { default as TrackOccupancyCanvas } from './components/TrackOccupancyCanvas';
+export { default as TrackOccupancyManchette } from './components/TrackOccupancyManchette';

--- a/ui-trackoccupancydiagram/src/styles/main.css
+++ b/ui-trackoccupancydiagram/src/styles/main.css
@@ -1,0 +1,3 @@
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';

--- a/ui-trackoccupancydiagram/tailwind.config.js
+++ b/ui-trackoccupancydiagram/tailwind.config.js
@@ -1,0 +1,6 @@
+import osrdUiPreset from '../tailwind-preset.js';
+/** @type {import('tailwindcss').Config} */
+export default {
+  presets: [osrdUiPreset],
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+};

--- a/ui-trackoccupancydiagram/tsconfig.json
+++ b/ui-trackoccupancydiagram/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["./src/**/*"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declarationDir": "./dist",
+    "typeRoots": ["./node_modules/@types", "../raw.d.ts"]
+  }
+}


### PR DESCRIPTION
the story is set in `storybook/stories` in order to anticipate the future migration of all stories in there.

close #703 