### PR TITLE
Build in parallel and enable caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ storybook-static
 # IDE
 .vscode/
 
+.nx/cache

--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,10 @@
+{
+  "targetDefaults": {
+    "build": {
+      "cache": true,
+      "outputs": [
+        "{projectRoot}/dist"
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "clean": "npm run clean --workspaces --if-present",
-    "build": "npm run build --workspaces --if-present",
+    "build": "lerna run build",
     "lint": "npm run lint --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "storybook": "npm start --workspace=@osrd-project/storybook",


### PR DESCRIPTION
### Use lerna to build in parallel

lerna is already a dependency. Use it so that packages get built
in parallel instead of sequentially.

### Cache builds with nx

Configure nx (used under-the-hood by lerna) to cache build
artifacts. Significantly decreases build time when a single
sub-package has changed.

* * *

Note that this relies more heavily on lerna, which on one hand is already a dependency, and on the other hand is quite overkill (e.g. supports sending build tasks to a remote machine)...

There is also a catch: on my machine nx just hangs because of https://github.com/nrwl/nx/issues/27494 (due to a `~/.gitignore` file).

An alternative would be to switch from rollup to a tool which supports on-disk cache, and then combine this with run-p. (With that approach we'd still need to spawn the build system for each sub-package when nothing has changed so would be a bit slower than nx. Also dependency tracking would be manual.)