### PR TITLE
Use ROLLUP_WATCH instead of NODE_ENV

### DIFF
--- a/rollup-base.config.js
+++ b/rollup-base.config.js
@@ -7,7 +7,6 @@ import livereload from 'rollup-plugin-livereload';
 import postcss from 'rollup-plugin-postcss';
 
 const formats = ['esm'];
-const isDev = process.env.NODE_ENV === 'development';
 
 /** @type {import("rollup").RollupOptions} */
 const generateRollupBaseConfig = (projectName, external) => ({
@@ -27,7 +26,7 @@ const generateRollupBaseConfig = (projectName, external) => ({
       plugins: [],
     }),
     terser(),
-    isDev &&
+    process.env.ROLLUP_WATCH &&
       livereload({
         watch: 'dist',
       }),

--- a/ui-core/package.json
+++ b/ui-core/package.json
@@ -30,7 +30,7 @@
     "rollup": "rollup -c",
     "clean": "rimraf dist",
     "build": "npm run rollup",
-    "watch": "NODE_ENV=development rollup -c -w",
+    "watch": "rollup -c -w",
     "test": "vitest run",
     "prepublishOnly": "npm run clean && npm run build",
     "lint": "eslint src --max-warnings 0",

--- a/ui-manchette-with-spacetimechart/package.json
+++ b/ui-manchette-with-spacetimechart/package.json
@@ -30,7 +30,7 @@
     "rollup": "rollup -c",
     "clean": "rimraf dist",
     "build": "npm run rollup",
-    "watch": "NODE_ENV=development rollup -c -w",
+    "watch": "rollup -c -w",
     "prepublishOnly": "npm run clean && npm run build",
     "lint": "eslint src --max-warnings 0",
     "lint:fix": "eslint src --fix",

--- a/ui-manchette/package.json
+++ b/ui-manchette/package.json
@@ -30,7 +30,7 @@
     "rollup": "rollup -c",
     "clean": "rimraf dist",
     "build": "npm run rollup",
-    "watch": "NODE_ENV=development rollup -c -w",
+    "watch": "rollup -c -w",
     "prepublishOnly": "npm run clean && npm run build",
     "lint": "eslint src --max-warnings 0",
     "lint:fix": "eslint src --fix"

--- a/ui-spacetimechart/package.json
+++ b/ui-spacetimechart/package.json
@@ -30,7 +30,7 @@
     "rollup": "rollup -c",
     "clean": "rimraf dist",
     "build": "npm run rollup",
-    "watch": "NODE_ENV=development rollup -c -w",
+    "watch": "rollup -c -w",
     "test": "vitest run --dir src/__tests__",
     "prepublishOnly": "npm run clean && npm run build",
     "lint": "eslint src --max-warnings 0",

--- a/ui-speedspacechart/package.json
+++ b/ui-speedspacechart/package.json
@@ -30,7 +30,7 @@
     "rollup": "rollup -c",
     "clean": "rimraf dist",
     "build": "npm run rollup",
-    "watch": "NODE_ENV=development rollup -c -w",
+    "watch": "rollup -c -w",
     "test": "vitest run --dir src/__tests__",
     "prepublishOnly": "npm run clean && npm run build",
     "lint": "eslint src --max-warnings 0",

--- a/ui-trackoccupancydiagram/package.json
+++ b/ui-trackoccupancydiagram/package.json
@@ -30,7 +30,7 @@
     "rollup": "rollup -c",
     "clean": "rimraf dist",
     "build": "npm run rollup",
-    "watch": "NODE_ENV=development rollup -c -w",
+    "watch": "rollup -c -w",
     "test": "vitest run --dir src/__tests__",
     "prepublishOnly": "npm run clean && npm run build",
     "lint": "eslint src --max-warnings 0",

--- a/ui-warped-map/package.json
+++ b/ui-warped-map/package.json
@@ -30,7 +30,7 @@
     "rollup": "rollup -c",
     "clean": "rimraf dist",
     "build": "npm run rollup",
-    "watch": "NODE_ENV=development rollup -c -w",
+    "watch": "rollup -c -w",
     "prepublishOnly": "npm run clean && npm run build",
     "lint": "eslint src --max-warnings 0",
     "lint:fix": "eslint src --fix"


### PR DESCRIPTION
We want to enable the livereload plugin when running in watch mode. We don't want to enable the livereload plugin when building, because that causes the build to hang forever.

NODE_ENV is the wrong tool for the job here: it can be set to "development" even when running `npm run build`, for instance if the user has set it globally (on a dev machine). In general, NODE_ENV is just supposed to indicate whether a Node.js app is running in production - nothing else.

Instead, use the ROLLUP_WATCH env var: it's set by rollup specifically when started in watch mode.