### PR TITLE
storybook: disable preserveSymlinks for vite resolve

### DIFF
--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -1,5 +1,4 @@
 import type { StorybookConfig } from '@storybook/react-vite';
-import { mergeConfig } from 'vite';
 
 /** @type { import('@storybook/html-vite').StorybookConfig } */
 const config: StorybookConfig = {
@@ -23,12 +22,5 @@ const config: StorybookConfig = {
   },
   staticDirs: ['../public'],
   logLevel: 'debug',
-  async viteFinal(config) {
-    return mergeConfig(config, {
-      resolve: {
-        preserveSymlinks: true,
-      },
-    });
-  },
 };
 export default config;


### PR DESCRIPTION
`preserveSymlinks` is for yarn only, it breaks NPM (keeps an old version of the dependencies around).

To test:

- `npm run watch` in ui-manchette and ui-manchette-with-spacetimechart
- `npm run storybook`
- Open the ui-manchette-with-spacetimechart story in the browser
- Add a `console.log()` in the `Waypoint` component

Before this patch, the log would never show up in the console. With this patch, it should live reload and show up.

Works on my machine™ as well as @SharglutDev's.