### PR TITLE
all: keep comments for TypeScript declaration files

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -42,7 +42,7 @@
     },
     "preserveConstEnums": true,
     "pretty": true,
-    "removeComments": true,
+    "removeComments": false,
     "resolveJsonModule": true,
     "rootDir": "./dist",
     "skipDefaultLibCheck": true,


### PR DESCRIPTION
removeComments unconditionally strips comments for all generated files. This is cumbersome for TypeScript declaration files (*.d.ts): users then don't have doc comments at hand (e.g. when using their editor's autocomplete or doc popup).

Fix this by turning off removeComments.

Comments in minified JavaScript files remain stripped (the minifier takes care of dropping these).

To test: add a comment to a field in `ManchetteProps`, check that it's preserved in `ui-manchette/dist/components/Manchette.d.ts`.