### PR TITLE
uicore: fixing combobox update

### DIFF
--- a/ui-core/src/components/inputs/ComboBox/ComboBox.tsx
+++ b/ui-core/src/components/inputs/ComboBox/ComboBox.tsx
@@ -114,7 +114,6 @@ const ComboBox = <T,>({
     } else {
       setInputValue('');
       setSelectedOption(null);
-      onSelectSuggestion?.(undefined);
     }
   }, [value]);
 


### PR DESCRIPTION
Currently, when refreshing, the combobox returns an empty value even if one has been selected. This modification fixes the problem.