### PR TITLE
Fix max speed utils function

### DIFF
--- a/ui-speedspacechart/src/__tests__/utils.spec.ts
+++ b/ui-speedspacechart/src/__tests__/utils.spec.ts
@@ -95,7 +95,7 @@ describe('getGraphOffsets', () => {
 
 describe('maxSpeedValue', () => {
   it('should return the correct maxSpeed', () => {
-    const maxSpeed = maxSpeedValue(store.speeds);
+    const maxSpeed = maxSpeedValue(store);
     expect(maxSpeed).toBe(30);
   });
 });

--- a/ui-speedspacechart/src/components/helpers/drawElements/axisY.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/axisY.ts
@@ -8,7 +8,7 @@ const TICK_WIDTH = 6;
 const TEXT_POSITION_X = 36;
 
 export const drawAxisY = ({ ctx, width, height, store }: DrawFunctionParams) => {
-  const maxSpeed = maxSpeedValue(store.speeds);
+  const maxSpeed = maxSpeedValue(store);
 
   clearCanvas(ctx, width, height);
 

--- a/ui-speedspacechart/src/components/helpers/drawElements/curve.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/curve.ts
@@ -44,7 +44,7 @@ export const drawCurve = ({ ctx, width, height, store }: DrawFunctionParams) => 
   ctx.save();
   ctx.translate(leftOffset, 0);
 
-  const maxSpeed = maxSpeedValue(store.speeds);
+  const maxSpeed = maxSpeedValue(store);
   const maxPosition = maxPositionValue(store.speeds);
 
   const curvePoints = computeCurvePoints(

--- a/ui-speedspacechart/src/components/helpers/drawElements/reticle.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/reticle.ts
@@ -53,7 +53,7 @@ export const drawCursor = ({ ctx, width, height, store }: DrawFunctionParams) =>
   let modeText = '';
   let reticleY = 0;
 
-  const maxSpeed = maxSpeedValue(store.speeds);
+  const maxSpeed = maxSpeedValue(store);
   const maxPosition = maxPositionValue(store.speeds);
 
   const heightWithoutLayers = getAdaptiveHeight(height, layersDisplay, false);

--- a/ui-speedspacechart/src/components/helpers/drawElements/speedLimits.ts
+++ b/ui-speedspacechart/src/components/helpers/drawElements/speedLimits.ts
@@ -23,7 +23,7 @@ export const drawSpeedLimits = ({ ctx, width, height, store }: DrawFunctionParam
   ctx.translate(leftOffset, 0);
 
   const realHeight = height - MARGIN_BOTTOM - MARGIN_TOP;
-  const maxSpeed = maxSpeedValue(store.speeds);
+  const maxSpeed = maxSpeedValue(store);
   const maxPosition = maxPositionValue(store.speeds);
 
   ctx.lineCap = 'round';

--- a/ui-speedspacechart/src/components/utils.ts
+++ b/ui-speedspacechart/src/components/utils.ts
@@ -22,12 +22,18 @@ export const getGraphOffsets = (width: number, height: number, declivities?: boo
 };
 
 /**
- * /**
- * Given a list of speed data, return the maxSpeed
- * @param speeds
+ * Given the store, return the max speed value.
+ * Can be either the max speed value from the MRSP or the max speed value from the speeds,
+ * depending on the layers displayed.
+ * @param store
  */
-export const maxSpeedValue = (speeds: LayerData<number>[]) =>
-  Math.max(...speeds.map(({ value }) => value));
+export const maxSpeedValue = (store: Store) => {
+  if (store.layersDisplay.speedLimits && store.mrsp) {
+    return Math.max(...store.mrsp.values.map(({ speed }) => speed));
+  }
+  return Math.max(...store.speeds.map(({ value }) => value));
+};
+
 /**
  * Given a list of speed data return the max position
  * @param speeds


### PR DESCRIPTION
close https://github.com/OpenRailAssociation/osrd/issues/9307

When the speed limits layer is enabled the max speed value to compute must be computed from the mrsp field.

**Render:**
![image](https://github.com/user-attachments/assets/7ce455a3-afef-4e5a-88a8-3303b586a889)

![image](https://github.com/user-attachments/assets/7fb4db64-d7a0-4dfb-8e5b-cef4f1a5f9d8)
