### PR TITLE
ui-core: remove HTMLLabelElement from radio button props

### DIFF
--- a/ui-core/src/components/inputs/RadioButton.tsx
+++ b/ui-core/src/components/inputs/RadioButton.tsx
@@ -4,10 +4,7 @@ import cx from 'classnames';
 
 import useFocusByTab from '../../hooks/useFocusByTab';
 
-export type RadioButtonProps = Omit<
-  React.InputHTMLAttributes<HTMLInputElement | HTMLLabelElement>,
-  'value'
-> & {
+export type RadioButtonProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value'> & {
   label: string;
   value: string;
   hint?: string;

--- a/ui-core/src/components/inputs/RadioGroup.tsx
+++ b/ui-core/src/components/inputs/RadioGroup.tsx
@@ -32,10 +32,7 @@ const RadioGroup = ({
 }: RadioGroupProps) => {
   const [selectedValue, setSelectedValue] = useState<string | undefined>(value);
 
-  const handleOptionChange = (
-    e: ChangeEvent<HTMLInputElement | HTMLLabelElement>,
-    nextOption: RadioButtonProps
-  ) => {
+  const handleOptionChange = (e: ChangeEvent<HTMLInputElement>, nextOption: RadioButtonProps) => {
     if (!readOnly) {
       setSelectedValue(nextOption.value);
       nextOption.onChange?.(e);


### PR DESCRIPTION
These props are forwarded to an `<input>` element, they are never passed to a `<label>` element.