### PR TITLE
all: add lodash types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@rollup/plugin-eslint": "^9.0.5",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^12.1.0",
+        "@types/lodash": "^4.17.13",
         "@types/react": "^18.2.40",
         "@types/react-dom": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
@@ -4909,6 +4910,13 @@
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@rollup/plugin-eslint": "^9.0.5",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.0",
+    "@types/lodash": "^4.17.13",
     "@types/react": "^18.2.40",
     "@types/react-dom": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",


### PR DESCRIPTION
Fixes warnings such as the following:

    (!) [plugin typescript] src/components/TransformedDataMap.tsx (6:22): @rollup/plugin-typescript TS7016: Could not find a declaration file for module 'lodash'. '/home/simon/src/osrd-ui/node_modules/lodash/lodash.js' implicitly has an 'any' type.
      Try `npm i --save-dev @types/lodash` if it exists or add a new declaration (.d.ts) file containing `declare module 'lodash';`
    /home/simon/src/osrd-ui/ui-warped-map/src/components/TransformedDataMap.tsx:6:22

    6 import { omit } from 'lodash';