### PR TITLE
core: refacto combo box

### DIFF
--- a/ui-core/src/components/inputs/ComboBox/index.ts
+++ b/ui-core/src/components/inputs/ComboBox/index.ts
@@ -1,1 +1,3 @@
-export { default as ComboBox, type ComboBoxProps } from './ComboBox';
+export { default, type ComboBoxProps } from './ComboBox';
+
+export { default as useDefaultComboBox } from './useDefaultComboBox';

--- a/ui-core/src/components/inputs/ComboBox/useDefaultComboBox.ts
+++ b/ui-core/src/components/inputs/ComboBox/useDefaultComboBox.ts
@@ -1,0 +1,56 @@
+import { useMemo, useState } from 'react';
+
+const normalizeString = (str: string) => str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
+const defaultFilterSuggestions = <T>(
+  getSuggestionLabel: (suggestion: T) => string,
+  suggestions: T[],
+  query: string
+) => {
+  const input = normalizeString(query).trim().toLowerCase();
+  if (!input) {
+    return suggestions;
+  }
+
+  const getSuggestionScore = (suggestion: T) => {
+    const suggestionLabel = normalizeString(getSuggestionLabel(suggestion).toLowerCase());
+    if (suggestionLabel.startsWith(input)) {
+      return 2;
+    }
+    if (suggestionLabel.includes(input)) {
+      return 1;
+    }
+    return 0;
+  };
+
+  return suggestions
+    .map((suggestion) => ({
+      suggestion,
+      score: getSuggestionScore(suggestion),
+    }))
+    .filter(({ score }) => score > 0)
+    .sort(({ score: scoreA }, { score: scoreB }) => scoreB - scoreA)
+    .map(({ suggestion }) => suggestion);
+};
+
+const useDefaultComboBox = <T>(suggestions: T[], getSuggestionLabel: (suggestion: T) => string) => {
+  const [query, setQuery] = useState('');
+
+  const filteredSuggestions = useMemo(
+    () => defaultFilterSuggestions(getSuggestionLabel, suggestions, query),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [suggestions, query]
+  );
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+  };
+
+  const resetSuggestions = () => {
+    setQuery('');
+  };
+
+  return { suggestions: filteredSuggestions, onChange, resetSuggestions };
+};
+
+export default useDefaultComboBox;

--- a/ui-core/src/components/inputs/ComboBox/utils.ts
+++ b/ui-core/src/components/inputs/ComboBox/utils.ts
@@ -1,2 +1,0 @@
-export const normalizeString = (str: string) =>
-  str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');

--- a/ui-core/src/index.ts
+++ b/ui-core/src/index.ts
@@ -1,7 +1,11 @@
 import './styles/main.css';
 
 export { default as Button, ButtonProps } from './components/buttons/Button';
-export { ComboBox, type ComboBoxProps } from './components/inputs/ComboBox';
+export {
+  default as ComboBox,
+  type ComboBoxProps,
+  useDefaultComboBox,
+} from './components/inputs/ComboBox';
 export {
   Checkbox,
   CheckboxList,

--- a/ui-core/src/stories/ComboBox.stories.tsx
+++ b/ui-core/src/stories/ComboBox.stories.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react';
 import '@osrd-project/ui-core/dist/theme.css';
 
-import { ComboBox } from '../components/inputs/ComboBox';
+import ComboBox from '../components/inputs/ComboBox';
+import useDefaultComboBox from '../components/inputs/ComboBox/useDefaultComboBox';
 
 type Suggestion = { id: string; label: string };
 
@@ -22,24 +23,39 @@ const suggestions = [
   { id: '12', label: 'Miguel' },
 ] as Suggestion[];
 
-const meta: Meta<typeof ComboBox> = {
-  component: ComboBox,
+const ComboBoxStory = (props: { small?: boolean; disabled?: boolean; readOnly?: boolean }) => {
+  const [value, setValue] = useState<Suggestion>();
+
+  const getSuggestionLabel = (suggestion: Suggestion) => suggestion.label;
+
+  const onSelectSuggestion = (suggestion?: Suggestion) => {
+    setValue(suggestion);
+  };
+
+  const comboBoxDefaultProps = useDefaultComboBox(suggestions, getSuggestionLabel);
+
+  return (
+    <div style={{ maxWidth: '20rem' }}>
+      <ComboBox
+        id="combo-box-custom"
+        value={value}
+        getSuggestionLabel={getSuggestionLabel}
+        onSelectSuggestion={onSelectSuggestion}
+        {...comboBoxDefaultProps}
+        {...props}
+      />
+    </div>
+  );
+};
+
+const meta: Meta<typeof ComboBoxStory> = {
+  component: ComboBoxStory,
   args: {
     small: false,
     disabled: false,
     readOnly: false,
-    onChange: () => {},
-    onSelectSuggestion: () => {},
-    getSuggestionLabel: (option) => (option as Suggestion).label,
-    suggestions: suggestions,
   },
-  decorators: [
-    (Story) => (
-      <div style={{ maxWidth: '20rem' }}>
-        <Story />
-      </div>
-    ),
-  ],
+  render: (props) => <ComboBoxStory {...props} />,
   title: 'core/ComboBox',
   tags: ['autodocs'],
 };
@@ -51,7 +67,6 @@ export const Default: Story = {
   args: {
     label: 'Your name',
     type: 'text',
-    defaultValue: '',
   },
 };
 
@@ -63,7 +78,7 @@ export const LongText: Story = {
       { id: '1', label: 'Very very very very very very long value 1' },
       { id: '2', label: 'Very very very very very very long value 2' },
     ],
-    value: 'Very very very very very very long value 1',
+    value: { id: '1', label: 'Very very very very very very long value 1' },
   },
 };
 
@@ -71,7 +86,7 @@ export const WithDefaultValue: Story = {
   args: {
     label: 'Your name',
     type: 'text',
-    value: 'Manolo',
+    value: { id: '4', label: 'Manolo' },
   },
 };
 
@@ -116,13 +131,5 @@ export const SmallInput: Story = {
     type: 'text',
     required: true,
     small: true,
-  },
-};
-
-export const DisabledDefaultFilter: Story = {
-  args: {
-    label: 'Name',
-    type: 'text',
-    disableDefaultFilter: true,
   },
 };

--- a/ui-core/src/stories/ComboBoxCustom.stories.tsx
+++ b/ui-core/src/stories/ComboBoxCustom.stories.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+
+import { type StoryObj, type Meta } from '@storybook/react';
+
+import '@osrd-project/ui-core/dist/theme.css';
+import './stories.css';
+import ComboBox from '../components/inputs/ComboBox';
+
+type Suggestion = { id: string; firstname: string; lastname: string };
+
+const suggestions: Suggestion[] = [
+  { id: '1', firstname: 'Manuel', lastname: 'Garcia' },
+  { id: '2', firstname: 'Consuela', lastname: 'Rodriguez' },
+  { id: '3', firstname: 'Juan', lastname: 'Gonzales' },
+  { id: '4', firstname: 'Manolo', lastname: 'Fernandez' },
+  { id: '5', firstname: 'Maria', lastname: 'Lopez' },
+  { id: '6', firstname: 'Jose', lastname: 'Martinez' },
+  { id: '7', firstname: 'Ana', lastname: 'Sanchez' },
+  { id: '8', firstname: 'Pedro', lastname: 'Perez' },
+  { id: '9', firstname: 'Lucia', lastname: 'Gomez' },
+  { id: '10', firstname: 'Carlos', lastname: 'Martin' },
+  { id: '11', firstname: 'Elena', lastname: 'Jimenez' },
+  { id: '12', firstname: 'Miguel', lastname: 'Ruiz' },
+];
+
+const ComboBoxStory = () => {
+  const [value, setValue] = useState<Suggestion>();
+  const [filteredSuggestions, setFilteredSuggestions] = useState<Suggestion[]>(suggestions);
+
+  const getSuggestionLabel = (suggestion: Suggestion) =>
+    `${suggestion.firstname} ${suggestion.lastname}`;
+
+  const onSelectSuggestion = (suggestion?: Suggestion) => {
+    setValue(suggestion);
+  };
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value.toLowerCase();
+    if (!inputValue) {
+      setFilteredSuggestions(suggestions);
+      return;
+    }
+    setFilteredSuggestions(
+      suggestions.filter((suggestion) => suggestion.lastname.toLowerCase().startsWith(inputValue))
+    );
+  };
+
+  const resetSuggestions = () => {
+    setFilteredSuggestions(suggestions);
+  };
+
+  return (
+    <div style={{ maxWidth: '20rem' }}>
+      <p style={{ textAlign: 'center' }}>
+        This comboBox filters on the last name using the OnChange props and not the
+        filterSuggestions props
+      </p>
+      <ComboBox
+        id="combo-box-custom"
+        value={value}
+        suggestions={filteredSuggestions}
+        getSuggestionLabel={getSuggestionLabel}
+        onSelectSuggestion={onSelectSuggestion}
+        resetSuggestions={resetSuggestions}
+        onChange={onChange}
+      />
+    </div>
+  );
+};
+
+const meta: Meta<typeof ComboBoxStory> = {
+  component: ComboBoxStory,
+  parameters: {
+    docs: {
+      story: {
+        height: '500px',
+      },
+    },
+  },
+  args: {},
+  title: 'core/ComboBox',
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ComboBox>;
+
+export const CustomBehavior: Story = {
+  args: {},
+};

--- a/ui-core/src/styles/inputs/comboBox.css
+++ b/ui-core/src/styles/inputs/comboBox.css
@@ -29,17 +29,17 @@
       0px 1px 0px rgba(235, 235, 234, 1) inset,
       0px -1px 0px rgba(182, 178, 175, 1) inset;
 
-    &.active {
+    &.selected {
       @apply bg-selection-20;
+    }
+
+    &.active {
+      @apply bg-primary-5;
     }
 
     &.small {
       font-size: 0.75rem;
       padding: 0.563rem 0.5rem 0.688rem;
-    }
-
-    &:hover {
-      @apply bg-primary-5;
     }
   }
 }


### PR DESCRIPTION
closes #778 

Here are the main changes:
- the combo box takes now a value of type T and not a string anymore
- the combo box has a default behavior (filters on the labels) but a custom behaviour can be used
- the hook useOutsideClick replaces the previous handleParentDivBlur function
- a new story has been added to test the custom behavior