### PR TITLE
ui-trackoccupancydiagram: select zone on click

### DIFF
--- a/ui-trackoccupancydiagram/src/components/TrackOccupancyCanvas.tsx
+++ b/ui-trackoccupancydiagram/src/components/TrackOccupancyCanvas.tsx
@@ -13,6 +13,8 @@ const TrackOccupancyCanvas = ({
   useDraw,
   setCanvasesRoot,
   selectedTrainId,
+  setSelectedTrainId,
+  mousePosition,
 }: TrackOccupancyCanvasProps) => (
   <div
     id={`track-occupancy-canvas-${opId}`}
@@ -20,7 +22,12 @@ const TrackOccupancyCanvas = ({
     ref={setCanvasesRoot}
   >
     <TracksLayer useDraw={useDraw} />
-    <OccupancyZonesLayer useDraw={useDraw} selectedTrainId={selectedTrainId} />
+    <OccupancyZonesLayer
+      useDraw={useDraw}
+      selectedTrainId={selectedTrainId}
+      setSelectedTrainId={setSelectedTrainId}
+      mousePosition={mousePosition}
+    />
   </div>
 );
 

--- a/ui-trackoccupancydiagram/src/components/helpers/drawElements/drawTracks.ts
+++ b/ui-trackoccupancydiagram/src/components/helpers/drawElements/drawTracks.ts
@@ -59,6 +59,7 @@ export const drawTracks = ({
   timeScale,
 }: DrawTracksProps) => {
   ctx.clearRect(0, 0, width, height);
+  ctx.save();
 
   const minT = timeOrigin - timeScale * timePixelOffset;
   const maxT = minT + timeScale * width;
@@ -94,4 +95,5 @@ export const drawTracks = ({
       labelMarks,
     });
   });
+  ctx.restore();
 };

--- a/ui-trackoccupancydiagram/src/components/layers/OccupancyZonesLayer.tsx
+++ b/ui-trackoccupancydiagram/src/components/layers/OccupancyZonesLayer.tsx
@@ -10,9 +10,13 @@ import { drawOccupancyZones } from '../helpers/drawElements/drawOccupancyZones';
 const OccupancyZonesLayer = ({
   useDraw,
   selectedTrainId,
+  setSelectedTrainId,
+  mousePosition,
 }: {
   useDraw: (layer: LayerType, fn: DrawingFunction) => void;
   selectedTrainId: string;
+  setSelectedTrainId: (id: string) => void;
+  mousePosition: { x: number; y: number };
 }) => {
   const drawingFunction = useCallback<DrawingFunction>(
     (ctx, { getTimePixel, tracks, occupancyZones, trackOccupancyWidth, trackOccupancyHeight }) => {
@@ -25,9 +29,11 @@ const OccupancyZonesLayer = ({
           occupancyZones,
           getTimePixel,
           selectedTrainId,
+          setSelectedTrainId,
+          mousePosition,
         });
     },
-    [selectedTrainId]
+    [mousePosition, selectedTrainId, setSelectedTrainId]
   );
 
   useDraw('paths', drawingFunction);

--- a/ui-trackoccupancydiagram/src/components/types.ts
+++ b/ui-trackoccupancydiagram/src/components/types.ts
@@ -28,6 +28,8 @@ export type TrackOccupancyCanvasProps = {
   useDraw: (layer: LayerType, fn: DrawingFunction) => void;
   setCanvasesRoot: (root: HTMLDivElement | null) => void;
   selectedTrainId: string;
+  setSelectedTrainId: (id: string) => void;
+  mousePosition: { x: number; y: number };
 };
 
 export type TrackOccupancyManchetteProps = {


### PR DESCRIPTION
- setup mouseContext from spacetimechart
- isolate TrackOccupancyDiagram to import it in a new story component
- use selectedTrainId and setSelectedTrainId as props
- add train selection on click in drawOccupationZone based on mouse position

As precised in the [main feature ticket ](https://github.com/osrd-project/osrd-confidential/issues/864) the selected train is set by clicking on an occupation zone, we could add an enhancement in future for setting the selecting by clicking on the train name either, not done yet because of the complexity it brings.

The TrackOccupancyDiagram has been isolated to be called in a new story component, which will allow us to easily move it in ui-trackoccupancyDiagram if needed in another PR.

close #787 