### PR TITLE
github: group dependabot patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
       typescript-eslint:
         patterns:
           - "@typescript-eslint/*"
+      patch:
+        update-types:
+          - "patch"
     commit-message:
       prefix: "dependency:"
     open-pull-requests-limit: 100


### PR DESCRIPTION
This should reduce the number of pull requests opened by dependabot, and shouldn't cause issues since patch updates only contain bug fixes. This approach has been working well for osrd.