### PR TITLE
Fix unresolved dependencies 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       ],
       "devDependencies": {
         "@rollup/plugin-eslint": "^9.0.5",
+        "@rollup/plugin-node-resolve": "^16.0.0",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^12.1.0",
         "@types/lodash": "^4.17.13",
@@ -3033,6 +3034,38 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.0.tgz",
+      "integrity": "sha512-0FPvAeVUT/zdWoO0jnb/V5BlBsUSNfkIOtFHzMO4H9MOklrmQFY6FduVHKucNb/aTFxvnGhj4MNj/T1oNdDfNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve/node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/plugin-terser": {
       "version": "0.4.4",
@@ -7472,6 +7505,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -10175,6 +10218,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17923,6 +17923,7 @@
       "version": "0.0.1-dev",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
+        "@osrd-project/ui-icons": "0.0.1-dev",
         "classnames": "^2.5.1",
         "tailwindcss": "^3.4.1"
       },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "type": "module",
   "devDependencies": {
     "@rollup/plugin-eslint": "^9.0.5",
+    "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.0",
     "@types/lodash": "^4.17.13",

--- a/rollup-base.config.js
+++ b/rollup-base.config.js
@@ -1,15 +1,18 @@
 import process from 'process';
+import path from 'path';
 
 import eslint from '@rollup/plugin-eslint';
+import nodeResolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import livereload from 'rollup-plugin-livereload';
 import postcss from 'rollup-plugin-postcss';
 
 const formats = ['esm'];
+const rootDir = path.join(process.cwd(), '..');
 
 /** @type {import("rollup").RollupOptions} */
-const generateRollupBaseConfig = (projectName, external) => ({
+const generateRollupBaseConfig = (projectName) => ({
   input: 'src/index.ts',
   output: formats.map((format) => ({
     file: `dist/index.${format}.js`,
@@ -18,6 +21,7 @@ const generateRollupBaseConfig = (projectName, external) => ({
     sourcemap: true,
   })),
   plugins: [
+    nodeResolve({ rootDir }),
     eslint(),
     typescript(),
     postcss({
@@ -31,7 +35,12 @@ const generateRollupBaseConfig = (projectName, external) => ({
         watch: 'dist',
       }),
   ],
-  external,
+  external: (id, parent, isResolved) => {
+    if (!isResolved) return false;
+    const rel = path.relative(rootDir, id);
+    const filenames = rel.split(path.sep);
+    return filenames[0] === 'node_modules' || filenames[1] === 'dist';
+  },
 });
 
 export default generateRollupBaseConfig;

--- a/rollup-base.config.js
+++ b/rollup-base.config.js
@@ -10,14 +10,15 @@ import postcss from 'rollup-plugin-postcss';
 
 const formats = ['esm'];
 const rootDir = path.join(process.cwd(), '..');
+const name = path.basename(process.cwd());
 
 /** @type {import("rollup").RollupOptions} */
-const generateRollupBaseConfig = (projectName) => ({
+const generateRollupBaseConfig = () => ({
   input: 'src/index.ts',
   output: formats.map((format) => ({
     file: `dist/index.${format}.js`,
     format,
-    name: projectName,
+    name,
     sourcemap: true,
   })),
   plugins: [

--- a/ui-core/package.json
+++ b/ui-core/package.json
@@ -40,6 +40,7 @@
     "react": ">=18.0"
   },
   "dependencies": {
+    "@osrd-project/ui-icons": "0.0.1-dev",
     "classnames": "^2.5.1",
     "tailwindcss": "^3.4.1"
   },

--- a/ui-core/rollup.config.js
+++ b/ui-core/rollup.config.js
@@ -1,2 +1,3 @@
 import generateBaseRollupConfig from '../rollup-base.config.js';
-export default generateBaseRollupConfig('osrdcore', ['react']);
+
+export default generateBaseRollupConfig('osrdcore');

--- a/ui-core/rollup.config.js
+++ b/ui-core/rollup.config.js
@@ -1,3 +1,3 @@
 import generateBaseRollupConfig from '../rollup-base.config.js';
 
-export default generateBaseRollupConfig('osrdcore');
+export default generateBaseRollupConfig();

--- a/ui-manchette-with-spacetimechart/rollup.config.js
+++ b/ui-manchette-with-spacetimechart/rollup.config.js
@@ -1,2 +1,3 @@
 import generateBaseRollupConfig from '../rollup-base.config.js';
-export default generateBaseRollupConfig('osrdcore', ['react']);
+
+export default generateBaseRollupConfig('osrdcore');

--- a/ui-manchette-with-spacetimechart/rollup.config.js
+++ b/ui-manchette-with-spacetimechart/rollup.config.js
@@ -1,3 +1,3 @@
 import generateBaseRollupConfig from '../rollup-base.config.js';
 
-export default generateBaseRollupConfig('osrdcore');
+export default generateBaseRollupConfig();

--- a/ui-manchette/rollup.config.js
+++ b/ui-manchette/rollup.config.js
@@ -1,2 +1,3 @@
 import generateBaseRollupConfig from '../rollup-base.config.js';
-export default generateBaseRollupConfig('osrdcore', ['react']);
+
+export default generateBaseRollupConfig('osrdcore');

--- a/ui-manchette/rollup.config.js
+++ b/ui-manchette/rollup.config.js
@@ -1,3 +1,3 @@
 import generateBaseRollupConfig from '../rollup-base.config.js';
 
-export default generateBaseRollupConfig('osrdcore');
+export default generateBaseRollupConfig();

--- a/ui-spacetimechart/rollup.config.js
+++ b/ui-spacetimechart/rollup.config.js
@@ -1,3 +1,3 @@
 import generateBaseRollupConfig from '../rollup-base.config.js';
 
-export default generateBaseRollupConfig('osrdcore', ['react']);
+export default generateBaseRollupConfig('osrdcore');

--- a/ui-spacetimechart/rollup.config.js
+++ b/ui-spacetimechart/rollup.config.js
@@ -1,3 +1,3 @@
 import generateBaseRollupConfig from '../rollup-base.config.js';
 
-export default generateBaseRollupConfig('osrdcore');
+export default generateBaseRollupConfig();

--- a/ui-speedspacechart/rollup.config.js
+++ b/ui-speedspacechart/rollup.config.js
@@ -1,3 +1,3 @@
 import generateBaseRollupConfig from '../rollup-base.config.js';
 
-export default generateBaseRollupConfig('osrdcore', ['react']);
+export default generateBaseRollupConfig('osrdcore');

--- a/ui-speedspacechart/rollup.config.js
+++ b/ui-speedspacechart/rollup.config.js
@@ -1,3 +1,3 @@
 import generateBaseRollupConfig from '../rollup-base.config.js';
 
-export default generateBaseRollupConfig('osrdcore');
+export default generateBaseRollupConfig();

--- a/ui-trackoccupancydiagram/rollup.config.js
+++ b/ui-trackoccupancydiagram/rollup.config.js
@@ -1,3 +1,3 @@
 import generateBaseRollupConfig from '../rollup-base.config.js';
 
-export default generateBaseRollupConfig('osrdTrackOccupancyDiagram', ['react']);
+export default generateBaseRollupConfig('osrdTrackOccupancyDiagram');

--- a/ui-trackoccupancydiagram/rollup.config.js
+++ b/ui-trackoccupancydiagram/rollup.config.js
@@ -1,3 +1,3 @@
 import generateBaseRollupConfig from '../rollup-base.config.js';
 
-export default generateBaseRollupConfig('osrdTrackOccupancyDiagram');
+export default generateBaseRollupConfig();

--- a/ui-warped-map/rollup.config.js
+++ b/ui-warped-map/rollup.config.js
@@ -1,18 +1,3 @@
-import typescript from '@rollup/plugin-typescript';
-import terser from '@rollup/plugin-terser';
-import eslint from '@rollup/plugin-eslint';
+import generateBaseRollupConfig from '../rollup-base.config.js';
 
-const formats = ['esm'];
-
-/** @type {import('rollup').RollupOptions} */
-export default {
-  input: 'src/index.ts',
-  output: formats.map((format) => ({
-    file: `dist/index.${format}.js`,
-    format,
-    name: 'osrdwarpedmap',
-    sourcemap: true,
-  })),
-  plugins: [eslint(), typescript(), terser()],
-  external: ['react'],
-};
+export default generateBaseRollupConfig();


### PR DESCRIPTION
_See individual commits._

We don't want to include our dependencies (react, maplibre, and so
on) in the osrd-ui library bundle: because library users download these as
transitive deps we want to leave it up to them to resolve the
imports and include them in the final app bundle. For instance,
OSRD is responsible for inlining maplibre imports in ui-warped-map's
bundle.

On the other hand, relative imports local to the package should be
bundled.

By default, rollup only resolves relative imports, and doesn't
resolve global imports. rollup prints an error when it encounters
a global import that it can't resolve. We don't want to just
ignore unresolved global imports, because that would silently
allow broken non-existing imports.

The @rollup/plugin-node-resolve plugin allows rollup to resolve
global imports like node does. However, by default it includes
all global imports in the bundle. This isn't what we want: we
want to exclude dependencies from the bundle.

To fix this, follow the recommendations in the [rollup docs][1]
and use the "external" option to check whether an import points
to the "node_modules" directory or a "dist" directory of any
osrd-ui package. In that case, ask rollup to not bundle the
import.

We don't need to manually specify a list of external imports
from each package anymore.

[1]: https://rollupjs.org/configuration-options/#external