### PR TITLE
ui-core: fix input status info close button

### DIFF
--- a/ui-core/src/components/inputs/StatusMessage.tsx
+++ b/ui-core/src/components/inputs/StatusMessage.tsx
@@ -37,7 +37,7 @@ const StatusMessage = ({ statusWithMessage, showIcon, small, onClose }: StatusMe
     >
       {showIcon && <InputStatusIcon status={status} small={small} />}
       <span className={cx('status-message', { [status]: status })}>{message}</span>
-      {status === 'info' && (
+      {status === 'info' && tooltip && (
         <button className="status-close" onClick={onClose}>
           <X size="sm" />
         </button>


### PR DESCRIPTION
In tooltip status, a close button is present to close the tooltip but it shouldn't be there if the status isn't a tooltip.

Before
![Capture d’écran 2025-01-14 à 14 20 17](https://github.com/user-attachments/assets/5908074b-a8da-44e5-a778-1525efb6a293)

After
![Capture d’écran 2025-01-14 à 14 25 07](https://github.com/user-attachments/assets/7e318150-7110-4c0a-849c-16888733e165)
