### PR TITLE
ui-warped-map: downgrade maplibre-gl to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11310,9 +11310,10 @@
       "dev": true
     },
     "node_modules/maplibre-gl": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.0.1.tgz",
-      "integrity": "sha512-kNvod1Tq0BcZvn43UAciA3DrzaEGmowqMoI6nh3kUo9rf+7m89mFJI9dELxkWzJ/N9Pgnkp7xF1jzTP08PGpCw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
+      "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -11321,14 +11322,14 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^23.0.0",
-        "@types/geojson": "^7946.0.15",
+        "@maplibre/maplibre-gl-style-spec": "^20.3.1",
+        "@types/geojson": "^7946.0.14",
         "@types/geojson-vt": "3.2.5",
         "@types/mapbox__point-geometry": "^0.1.4",
         "@types/mapbox__vector-tile": "^1.3.4",
         "@types/pbf": "^3.0.5",
         "@types/supercluster": "^7.1.3",
-        "earcut": "^3.0.1",
+        "earcut": "^3.0.0",
         "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.3",
         "global-prefix": "^4.0.0",
@@ -11350,15 +11351,16 @@
       }
     },
     "node_modules/maplibre-gl/node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-23.0.0.tgz",
-      "integrity": "sha512-Q3L4TTs/cAuebQolBrDvfoLj3f/9C+wo2qiup9paye+e77IXoAAoZnR+2M/qEiZWAPfPZWuARLx81a5PN5LTUw==",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
+      "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
+      "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
-        "quickselect": "^3.0.0",
+        "quickselect": "^2.0.0",
         "rw": "^1.3.3",
         "tinyqueue": "^3.0.0"
       },
@@ -11368,15 +11370,23 @@
         "gl-style-validate": "dist/gl-style-validate.mjs"
       }
     },
+    "node_modules/maplibre-gl/node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
     "node_modules/maplibre-gl/node_modules/json-stringify-pretty-compact": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
-      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q=="
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
     },
     "node_modules/maplibre-gl/node_modules/quickselect": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
-      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g=="
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -18182,7 +18192,7 @@
         "@turf/simplify": "^7.1.0",
         "@turf/transform-translate": "^7.1.0",
         "lodash": "^4.17.21",
-        "maplibre-gl": "^5.0.0",
+        "maplibre-gl": "^4.7.1",
         "react-map-gl": "^7.1.7"
       },
       "peerDependencies": {

--- a/ui-warped-map/package.json
+++ b/ui-warped-map/package.json
@@ -60,7 +60,7 @@
     "@turf/simplify": "^7.1.0",
     "@turf/transform-translate": "^7.1.0",
     "lodash": "^4.17.21",
-    "maplibre-gl": "^5.0.0",
+    "maplibre-gl": "^4.7.1",
     "react-map-gl": "^7.1.7"
   },
   "peerDependencies": {


### PR DESCRIPTION
maplibre-gl v5 causes multiple issues:

- The story is broken (JavaScript error trying to set pixelsToGLUnits). Upstream bug report: https://github.com/visgl/react-map-gl/issues/2460
- A new TypeScript error pops up, went unnoticed because CI doesn't fail on these:

  ```
    (!) [plugin typescript] src/components/DataLoader.tsx (61:43): @rollup/plugin-typescript TS2345: Argument of type 'GeoJSONFeature' is not assignable to parameter of type 'MapGeoJSONFeature'.
      Type 'GeoJSONFeature' is missing the following properties from type '{ layer: (Omit<FillLayerSpecification, "source"> | Omit<LineLayerSpecification, "source"> | Omit<SymbolLayerSpecification, "source"> | ... 5 more ... | Omit<...>) & { ...; }; source: string; sourceLayer?: string | undefined; state: { ...; }; }': layer, source, state
    /home/simon/src/osrd-ui/ui-warped-map/src/components/DataLoader.tsx:61:43

    61               .map((f) => simplifyFeature(f, sourceLayer));
  ```

This commit effectively reverts #797