### PR TITLE
build: build ui-icons before ui-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "url": "https://github.com/osrd-project/osrd-ui/issues"
   },
   "workspaces": [
-    "ui-core",
     "ui-icons",
+    "ui-core",
     "ui-spacetimechart",
     "ui-speedspacechart",
     "ui-warped-map",


### PR DESCRIPTION
ui-core depends on ui-icons. Ensure it gets build before to fix unresolved module errors.