### PR TITLE
build: use rollup --failAfterWarnings

### DIFF
--- a/ui-spacetimechart/package.json
+++ b/ui-spacetimechart/package.json
@@ -27,9 +27,8 @@
     }
   },
   "scripts": {
-    "rollup": "rollup -c",
     "clean": "rimraf dist",
-    "build": "npm run rollup",
+    "build": "rollup -c --failAfterWarnings",
     "watch": "rollup -c -w",
     "test": "vitest run --dir src/__tests__",
     "prepublishOnly": "npm run clean && npm run build",

--- a/ui-trackoccupancydiagram/package.json
+++ b/ui-trackoccupancydiagram/package.json
@@ -27,9 +27,8 @@
     }
   },
   "scripts": {
-    "rollup": "rollup -c",
     "clean": "rimraf dist",
-    "build": "npm run rollup",
+    "build": "rollup -c --failAfterWarnings",
     "watch": "rollup -c -w",
     "test": "vitest run --dir src/__tests__",
     "prepublishOnly": "npm run clean && npm run build",


### PR DESCRIPTION
We've got to a point where we've eliminated all build errors. We
previously did not notice these because they only show up as
warnings in CI, without making CI fail.

Use rollup --failAfterWarnings so that CI fails when a build error
is emitted.

Depends on #832