### PR TITLE
ui-manchette: add missing ui-icons dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18094,6 +18094,7 @@
       "version": "0.0.1-dev",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
+        "@osrd-project/ui-icons": "0.0.1-dev",
         "classnames": "^2.5.1",
         "lodash.isequal": "^4.5.0"
       },

--- a/ui-manchette/package.json
+++ b/ui-manchette/package.json
@@ -36,6 +36,7 @@
     "lint:fix": "eslint src --fix"
   },
   "dependencies": {
+    "@osrd-project/ui-icons": "0.0.1-dev",
     "classnames": "^2.5.1",
     "lodash.isequal": "^4.5.0"
   },


### PR DESCRIPTION
ZoomIn and ZoomOut are used in ui-manchette.