### PR TITLE
all: stop importing CSS files from library code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18601,6 +18601,10 @@
     },
     "storybook": {
       "name": "@osrd-project/storybook",
+      "dependencies": {
+        "@osrd-project/ui-core": "0.0.1-dev",
+        "@osrd-project/ui-trackoccupancydiagram": "0.0.1-dev"
+      },
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.0",
         "@storybook/addon-essentials": "^8.0.2",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -19,5 +19,9 @@
     "clean": "rimraf storybook-static",
     "start": "storybook dev -p 6006",
     "build": "storybook build"
+  },
+  "dependencies": {
+    "@osrd-project/ui-core": "0.0.1-dev",
+    "@osrd-project/ui-trackoccupancydiagram": "0.0.1-dev"
   }
 }

--- a/storybook/stories/TrackOccupancyDiagram/TrackOccupancyDiagram.stories.tsx
+++ b/storybook/stories/TrackOccupancyDiagram/TrackOccupancyDiagram.stories.tsx
@@ -37,6 +37,9 @@ import {
 import occupancyZones from '../samples/TrackOccupancyDiagramSamples/occupancyZones';
 import tracks from '../samples/TrackOccupancyDiagramSamples/tracks';
 
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-trackoccupancydiagram/dist/theme.css';
+
 type TrackOccupancyDiagramProps = {
   xZoomLevel: number;
   yZoomLevel: number;

--- a/ui-core/src/index.ts
+++ b/ui-core/src/index.ts
@@ -1,5 +1,3 @@
-import './styles/main.css';
-
 export { default as Button, ButtonProps } from './components/buttons/Button';
 export {
   default as ComboBox,

--- a/ui-manchette-with-spacetimechart/src/index.ts
+++ b/ui-manchette-with-spacetimechart/src/index.ts
@@ -1,5 +1,3 @@
-import './styles/main.css';
-
 export { default as useManchettesWithSpaceTimeChart } from './hooks/useManchetteWithSpaceTimeChart';
 export { DEFAULT_ZOOM_MS_PER_PX } from './consts';
 export { timeScaleToZoomValue } from './helpers';

--- a/ui-manchette/src/components/Waypoint.tsx
+++ b/ui-manchette/src/components/Waypoint.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import cx from 'classnames';
 
 import { type InteractiveWaypoint } from '../types';
-import '@osrd-project/ui-core/dist/theme.css';
 import { positionMmToKm } from '../utils';
 
 type WaypointProps = {

--- a/ui-manchette/src/index.ts
+++ b/ui-manchette/src/index.ts
@@ -1,5 +1,3 @@
-import '@osrd-project/ui-core/dist/theme.css';
-import './styles/main.css';
 import './components/consts';
 
 import Manchette from './components/Manchette';

--- a/ui-spacetimechart/src/index.ts
+++ b/ui-spacetimechart/src/index.ts
@@ -1,5 +1,3 @@
-import './styles/main.css';
-
 export type { HoveredItem, SpaceTimeChartProps } from './lib/types';
 
 export * from './components/SpaceTimeChart';

--- a/ui-speedspacechart/src/index.ts
+++ b/ui-speedspacechart/src/index.ts
@@ -1,4 +1,1 @@
-import '@osrd-project/ui-core/dist/theme.css';
-import './styles/main.css';
-
 export { default as SpeedSpaceChart } from './components/SpeedSpaceChart';

--- a/ui-trackoccupancydiagram/src/index.ts
+++ b/ui-trackoccupancydiagram/src/index.ts
@@ -1,5 +1,2 @@
-import '@osrd-project/ui-core/dist/theme.css';
-import './styles/main.css';
-
 export { default as TrackOccupancyCanvas } from './components/TrackOccupancyCanvas';
 export { default as TrackOccupancyManchette } from './components/TrackOccupancyManchette';


### PR DESCRIPTION
We were importing CSS files directly from library code. This causes issues for downstream users, because they are forced to configure their build system to support CSS imports (these aren't standard JS, e.g. webpack doesn't support this by default). Moreover, this makes it impossible to use the library without a build system (e.g. importing it directly from pure HTML/JS files).

Make users responsible for including the CSS one way or another. Our stories do this using CSS imports already, but other downstream consumers might prefer to use a `<link>` or similar.