### PR TITLE
ci: upgrade NodeJS to version 23

### DIFF
--- a/.github/workflows/icons-optimize.yml
+++ b/.github/workflows/icons-optimize.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: '23'
       - run: |
           cd ui-icons
           npm install

--- a/.github/workflows/osrd-ui-build.yml
+++ b/.github/workflows/osrd-ui-build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '23'
 
       - name: Cache node_modules
         uses: actions/cache@v4

--- a/.github/workflows/osrd-ui-publish.yml
+++ b/.github/workflows/osrd-ui-publish.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '23'
 
       - name: Authenticate with Registry
         run: |

--- a/.github/workflows/osrd-ui-website.yml
+++ b/.github/workflows/osrd-ui-website.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '23'
 
       - name: Cache node_modules
         uses: actions/cache@v4


### PR DESCRIPTION
We don't need anything new from this release, but it's better to keep up with new versions to get bugfixes (older NodeJS versions get less support) and a heads-up for new deprecations.