### PR TITLE
storybook: drop getAbsolutePath()

### DIFF
--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -1,5 +1,4 @@
 import type { StorybookConfig } from '@storybook/react-vite';
-import { dirname, join } from 'path';
 import { mergeConfig } from 'vite';
 
 /** @type { import('@storybook/html-vite').StorybookConfig } */
@@ -10,12 +9,12 @@ const config: StorybookConfig = {
     '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)',
   ],
   addons: [
-    getAbsolutePath('@storybook/addon-links'),
-    getAbsolutePath('@storybook/addon-essentials'),
-    getAbsolutePath('@storybook/addon-interactions'),
-    getAbsolutePath('@storybook/addon-storysource'),
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+    '@storybook/addon-storysource',
   ],
-  framework: getAbsolutePath('@storybook/react-vite'),
+  framework: '@storybook/react-vite',
   typescript: {
     check: true,
   },
@@ -33,7 +32,3 @@ const config: StorybookConfig = {
   },
 };
 export default config;
-
-function getAbsolutePath(value: string): string {
-  return dirname(require.resolve(join(value, 'package.json')));
-}


### PR DESCRIPTION
Do like the official docs recommend and just use package names instead of trying to use absolute paths.

The motivation is that NodeJS 23 no longer defines a "require" global.

I couldn't find an explanation in the Git history which could indicate why getAbsolutePath() exists in the first place (been like this from the start).