### PR TITLE
build: don't mark CSS files as external

### DIFF
--- a/rollup-base.config.js
+++ b/rollup-base.config.js
@@ -38,6 +38,7 @@ const generateRollupBaseConfig = () => ({
   ],
   external: (id, parent, isResolved) => {
     if (!isResolved) return false;
+    if (id.endsWith('.css')) return false;
     const rel = path.relative(rootDir, id);
     const filenames = rel.split(path.sep);
     return filenames[0] === 'node_modules' || filenames[1] === 'dist';


### PR DESCRIPTION
When a file marked as external is imported, it's not included in the JS library bundle: the JS import is left as-is. This is desirable for regular JS dependencies such as react and maplibre-gl, but is undesirable for non-standard imports such as CSS files.

Indeed, CSS imports from our JS library bundle cause pain for downstream users, because they are forced to configure their build system to support CSS imports (these aren't standard JS, e.g. webpack doesn't support this by default). Moreover, this makes it impossible to use the library without a build system (e.g. importing it directly from pure HTML/JS files).

Make users responsible for including the CSS one way or another. Our stories do this using CSS imports already, but other downstream consumers might prefer to use a `<link>` or similar.

To test, build the project and check whether the first line in `ui-speedspacechart/dist/index.esm.js` contains a CSS import. It should not.

Fixes: 6dd85a7a64b1 ("build: fix unresolved dependencies")
Supersedes https://github.com/OpenRailAssociation/osrd-ui/pull/837