### PR TITLE
ui-manchette, ui-trackoccupancydiagram: add missing ui-core dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@osrd-project/root",
       "version": "0.0.1-dev",
       "workspaces": [
-        "ui-core",
         "ui-icons",
+        "ui-core",
         "ui-spacetimechart",
         "ui-speedspacechart",
         "ui-warped-map",
@@ -18732,6 +18732,7 @@
       "version": "0.0.1-dev",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
+        "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
         "classnames": "^2.5.1",
         "lodash.isequal": "^4.5.0"
@@ -18834,6 +18835,7 @@
       "version": "0.0.1-dev",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
+        "@osrd-project/ui-core": "0.0.1-dev",
         "@types/chroma-js": "^3.1.0",
         "chroma-js": "^3.1.1",
         "classnames": "^2.5.1",

--- a/ui-manchette/package.json
+++ b/ui-manchette/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@osrd-project/ui-icons": "0.0.1-dev",
+    "@osrd-project/ui-core": "0.0.1-dev",
     "classnames": "^2.5.1",
     "lodash.isequal": "^4.5.0"
   },

--- a/ui-manchette/src/components/Waypoint.tsx
+++ b/ui-manchette/src/components/Waypoint.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import cx from 'classnames';
 
 import { type InteractiveWaypoint } from '../types';
-import '@osrd-project/ui-core/dist/theme.css';
 import { positionMmToKm } from '../utils';
 
 type WaypointProps = {

--- a/ui-trackoccupancydiagram/package.json
+++ b/ui-trackoccupancydiagram/package.json
@@ -37,6 +37,7 @@
     "lint:fix": "eslint src --fix"
   },
   "dependencies": {
+    "@osrd-project/ui-core": "0.0.1-dev",
     "@types/chroma-js": "^3.1.0",
     "chroma-js": "^3.1.1",
     "classnames": "^2.5.1",


### PR DESCRIPTION
ui-core is used from these components, but is missing from dependencies. This makes the lerna build fail.

(Also a small cleanup for a duplicate CSS import.)

Test: `npm run clean && npx lerna run build`.

I've looked at all imports with these commands:

```sh
git grep "import '@osrd-project/" | grep -v stories
git grep "from '@osrd-project/" | grep -v stories
```