### PR TITLE
github: deploy website via actions/deploy-pages

### DIFF
--- a/.github/workflows/osrd-ui-website.yml
+++ b/.github/workflows/osrd-ui-website.yml
@@ -6,7 +6,7 @@ on:
     types: [created]
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -28,11 +28,22 @@ jobs:
           npm ci
           npm run build
 
-      - name: Deploy to GitHub Pages
-        uses: crazy-max/ghaction-github-pages@v4
+      - name: Upload artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
         with:
-          target_branch: gh-pages
-          build_dir: storybook/storybook-static
-          jekyll: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          path: storybook/storybook-static
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The old action was pushing commits to the gh-pages branch.
This is a bit of a hack, and GitHub has official actions to create
pages deployments instead.

See:

- https://github.com/actions/deploy-pages
- https://github.com/actions/upload-pages-artifact