### PR TITLE
build: disable TypeScript importHelpers

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,7 @@
     "esModuleInterop": true,
     "experimentalDecorators": false,
     "forceConsistentCasingInFileNames": true,
-    "importHelpers": true,
+    "importHelpers": false,
     "importsNotUsedAsValues": "remove",
     "inlineSourceMap": false,
     "inlineSources": false,


### PR DESCRIPTION
importHelpers requires tslib to be added as a dependency of all packages. This isn't the case currently and causes breakage:

    [vite]: Rollup failed to resolve import "/home/runner/work/osrd-ui/osrd-ui/node_modules/tslib/tslib.es6.js" from "/app/node_modules/@osrd-project/ui-core/dist/index.esm.js".

https://github.com/OpenRailAssociation/osrd/actions/runs/13162122589/job/36733250608?pr=10697#step:6:516

We don't use downlevelIteration so don't gain anything from enabling this.