### PR TITLE
build: use esnext for TypeScript module/target

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,7 +24,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "listEmittedFiles": false,
     "listFiles": false,
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
     "noEmit": false,
     "noEmitHelpers": false,
@@ -56,6 +56,6 @@
     "stripInternal": true,
     "suppressExcessPropertyErrors": false,
     "suppressImplicitAnyIndexErrors": false,
-    "target": "es6"
+    "target": "esnext"
   }
 }


### PR DESCRIPTION
Modernize our TypeScript config file to use ESNext instead of legacy CommonJS.

The same values are already used in osrd.