### PR TITLE
ui-manchette-with-space-time-chart: return xZoom

### DIFF
--- a/ui-manchette-with-spacetimechart/src/hooks/useManchetteWithSpaceTimeChart.ts
+++ b/ui-manchette-with-spacetimechart/src/hooks/useManchetteWithSpaceTimeChart.ts
@@ -240,8 +240,9 @@ const useManchettesWithSpaceTimeChart = (
       spaceTimeChartProps,
       handleScroll,
       handleXZoom,
+      xZoom,
     }),
-    [manchetteProps, spaceTimeChartProps, handleScroll, handleXZoom]
+    [manchetteProps, spaceTimeChartProps, handleScroll, handleXZoom, xZoom]
   );
 };
 


### PR DESCRIPTION
This props was removed accidently [here](https://github.com/OpenRailAssociation/osrd-ui/commit/ab5aa4e8c2f352482d8c5b44d74aee43b0dae8d5).
Since it is missing, we can't bump osrd-ui in osrd.