### PR TITLE
build: use rollup --failAfterWarnings, diet version

### DIFF
--- a/ui-core/package.json
+++ b/ui-core/package.json
@@ -27,9 +27,8 @@
     }
   },
   "scripts": {
-    "rollup": "rollup -c",
     "clean": "rimraf dist",
-    "build": "npm run rollup",
+    "build": "rollup -c --failAfterWarnings",
     "watch": "rollup -c -w",
     "test": "vitest run",
     "prepublishOnly": "npm run clean && npm run build",

--- a/ui-icons/package.json
+++ b/ui-icons/package.json
@@ -26,10 +26,8 @@
   },
   "scripts": {
     "svgo": "svgo icons --config svgo.config.cjs",
-    "build-components": "node ./scripts/build.js",
-    "rollup": "rollup -c",
     "clean": "rimraf dist",
-    "build": "npm run build-components && npm run rollup",
+    "build": "node ./scripts/build.js && rollup -c --failAfterWarnings",
     "prepublishOnly": "npm run clean && npm run build"
   },
   "peerDependencies": {

--- a/ui-manchette-with-spacetimechart/package.json
+++ b/ui-manchette-with-spacetimechart/package.json
@@ -27,9 +27,8 @@
     }
   },
   "scripts": {
-    "rollup": "rollup -c",
     "clean": "rimraf dist",
-    "build": "npm run rollup",
+    "build": "rollup -c --failAfterWarnings",
     "watch": "rollup -c -w",
     "prepublishOnly": "npm run clean && npm run build",
     "lint": "eslint src --max-warnings 0",

--- a/ui-manchette/package.json
+++ b/ui-manchette/package.json
@@ -27,9 +27,8 @@
     }
   },
   "scripts": {
-    "rollup": "rollup -c",
     "clean": "rimraf dist",
-    "build": "npm run rollup",
+    "build": "rollup -c --failAfterWarnings",
     "watch": "rollup -c -w",
     "prepublishOnly": "npm run clean && npm run build",
     "lint": "eslint src --max-warnings 0",

--- a/ui-speedspacechart/package.json
+++ b/ui-speedspacechart/package.json
@@ -27,9 +27,8 @@
     }
   },
   "scripts": {
-    "rollup": "rollup -c",
     "clean": "rimraf dist",
-    "build": "npm run rollup",
+    "build": "rollup -c --failAfterWarnings",
     "watch": "rollup -c -w",
     "test": "vitest run --dir src/__tests__",
     "prepublishOnly": "npm run clean && npm run build",

--- a/ui-warped-map/package.json
+++ b/ui-warped-map/package.json
@@ -27,9 +27,8 @@
     }
   },
   "scripts": {
-    "rollup": "rollup -c",
     "clean": "rimraf dist",
-    "build": "npm run rollup",
+    "build": "rollup -c --failAfterWarnings",
     "watch": "rollup -c -w",
     "prepublishOnly": "npm run clean && npm run build",
     "lint": "eslint src --max-warnings 0",


### PR DESCRIPTION
We've got to a point where we've eliminated almost all build errors. We previously did not notice these because they only show up as warnings in CI, without making CI fail.

Use rollup --failAfterWarnings so that CI fails when a build error is emitted.

Leave ui-spacetimechart and ui-trackoccupancydiagram alone, because these still have a failure due to a circular dependency:

    (!) [plugin typescript] ../ui-spacetimechart/src/lib/types.ts (6:8): @rollup/plugin-typescript TS2307: Cannot find module '@osrd-project/ui-trackoccupancydiagram/dist/components/types' or its corresponding type declarations.
    /home/runner/work/osrd-ui/osrd-ui/ui-spacetimechart/src/lib/types.ts:6:8

    6 } from '@osrd-project/ui-trackoccupancydiagram/dist/components/types';
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

These remaining errors will be fixed when all charts are refactored into a single package.

Full version here: https://github.com/OpenRailAssociation/osrd-ui/pull/833