### PR TITLE
ui-spacetimechart: implements "splitting"

### DIFF
--- a/ui-spacetimechart/src/__tests__/paths.spec.ts
+++ b/ui-spacetimechart/src/__tests__/paths.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PathData } from '../lib/types';
+import { getPathDirection } from '../utils/paths';
+
+const PATH: PathData = {
+  id: 'path-back-and-forth',
+  label: 'Path',
+  points: [
+    { time: 0, position: 0 },
+    { time: 1, position: 0 },
+    { time: 2, position: 10 },
+    { time: 3, position: 30 },
+    { time: 4, position: 30 },
+    { time: 5, position: 20 },
+    { time: 6, position: 20 },
+    { time: 7, position: 0 },
+  ],
+};
+
+describe('getPathDirection', () => {
+  it('should return the expected directions in "normal" cases', () => {
+    // Test extremities:
+    expect(getPathDirection(PATH, 0)).toBe('forward');
+    expect(getPathDirection(PATH, 7, true)).toBe('backward');
+
+    // Test some normal step:
+    expect(getPathDirection(PATH, 2)).toBe('forward');
+    expect(getPathDirection(PATH, 2, true)).toBe('forward');
+
+    // Test some "U-turn" point:
+    expect(getPathDirection(PATH, 3)).toBe('backward');
+    expect(getPathDirection(PATH, 2, true)).toBe('forward');
+  });
+
+  it('should return the "stay" for undecidable cases', () => {
+    expect(getPathDirection(PATH, 0, true)).toBe('still');
+    expect(getPathDirection(PATH, 7)).toBe('still');
+  });
+});

--- a/ui-spacetimechart/src/__tests__/scales.spec.ts
+++ b/ui-spacetimechart/src/__tests__/scales.spec.ts
@@ -129,7 +129,7 @@ describe('getSpaceBreakpoints', () => {
       { to: 90, size: 50 },
       { to: 140, size: 50 },
     ]);
-    expect(getSpaceBreakpoints(5, 135, tree)).toEqual([10, 60, 70, 90]);
+    expect(getSpaceBreakpoints(5, 135, tree)).toEqual([10, 60, 60, 70, 90]);
   });
 });
 
@@ -171,9 +171,17 @@ describe('getNormalizedScaleAtPosition', () => {
       { to: 90, size: 50 },
       { to: 140, size: 50 },
     ]);
+
     expect(pick(getNormalizedScaleAtPosition(60, tree) as NormalizedScale, 'from', 'to')).toEqual({
       from: 10,
       to: 60,
+    });
+
+    expect(
+      pick(getNormalizedScaleAtPosition(60, tree, true) as NormalizedScale, 'from', 'to')
+    ).toEqual({
+      from: 60,
+      to: 70,
     });
   });
 

--- a/ui-spacetimechart/src/components/PathLayer.tsx
+++ b/ui-spacetimechart/src/components/PathLayer.tsx
@@ -21,27 +21,8 @@ import {
   getCrispLineCoordinate,
 } from '../utils/canvas';
 import { indexToColor, hexToRgb } from '../utils/colors';
+import { getPathDirection } from '../utils/paths';
 import { getSpaceBreakpoints } from '../utils/scales';
-
-function getDirection({ points }: PathData, reverse?: boolean): 'up' | 'down' {
-  if (points.length < 2) return 'down';
-
-  if (!reverse) {
-    for (let i = 1, l = Math.min(3, points.length); i < l; i++) {
-      const diff = points[i].position - points[i - 1].position;
-      if (diff > 0) return 'up';
-      if (diff < 0) return 'down';
-    }
-  } else {
-    for (let i = points.length - 2, l = Math.max(points.length - 4, points.length); i > l; i--) {
-      const diff = points[i].position - points[i + 1].position;
-      if (diff > 0) return 'up';
-      if (diff < 0) return 'down';
-    }
-  }
-
-  return 'down';
-}
 
 const DEFAULT_PICKING_TOLERANCE = 5;
 const PAUSE_THICKNESS = 7;
@@ -284,7 +265,6 @@ export const PathLayer = ({
     (ctx, { getTimePixel, getSpacePixel, swapAxis }) => {
       if (!path.points.length) return;
 
-      const pathDirection = getDirection(path);
       const from = path.points[0];
       const fromEnd = path.fromEnd || DEFAULT_PATH_END;
       const to = last(path.points) as DataPoint;
@@ -296,7 +276,7 @@ export const PathLayer = ({
         getSpacePixel(from.position),
         swapAxis,
         'from',
-        pathDirection,
+        getPathDirection(path, 0),
         fromEnd
       );
       drawPathExtremity(
@@ -305,7 +285,7 @@ export const PathLayer = ({
         getSpacePixel(to.position),
         swapAxis,
         'to',
-        pathDirection,
+        getPathDirection(path, path.points.length - 1, true),
         toEnd
       );
     },

--- a/ui-spacetimechart/src/components/PathLayer.tsx
+++ b/ui-spacetimechart/src/components/PathLayer.tsx
@@ -21,7 +21,7 @@ import {
   getCrispLineCoordinate,
 } from '../utils/canvas';
 import { indexToColor, hexToRgb } from '../utils/colors';
-import { getPathDirection } from '../utils/paths';
+import { getPathDirection, getSpacePixels } from '../utils/paths';
 import { getSpaceBreakpoints } from '../utils/scales';
 
 const DEFAULT_PICKING_TOLERANCE = 5;
@@ -102,14 +102,27 @@ export const PathLayer = ({
         } else {
           const { position: prevPosition, time: prevTime } = a[i - 1];
           const spaceBreakPoints = getSpaceBreakpoints(prevPosition, position, spaceScaleTree);
-          spaceBreakPoints.forEach((breakPosition) => {
+          let previousBreakPosition = -Infinity;
+          spaceBreakPoints.forEach((breakPosition, index) => {
+            const nextBreakPosition = spaceBreakPoints[index + 1] ?? Infinity;
+            const isBeforeFlatStep = previousBreakPosition === breakPosition;
+            const isAfterFlatStep = breakPosition === nextBreakPosition;
+
+            const readSpacePixelFromEnd = isBeforeFlatStep
+              ? getPathDirection(path, i, true) === 'forward'
+              : isAfterFlatStep
+                ? getPathDirection(path, i - 1) === 'backward'
+                : false;
+
             const breakTime =
               prevTime +
               ((breakPosition - prevPosition) / (position - prevPosition)) * (time - prevTime);
+
             res.push({
               [timeAxis]: getTimePixel(breakTime),
-              [spaceAxis]: getSpacePixel(breakPosition),
+              [spaceAxis]: getSpacePixel(breakPosition, readSpacePixelFromEnd),
             } as Point);
+            previousBreakPosition = breakPosition;
           });
           res.push({
             [timeAxis]: getTimePixel(time),
@@ -156,16 +169,19 @@ export const PathLayer = ({
         if (i) {
           const { position: prevPosition, time: prevTime } = a[i - 1];
           if (prevPosition === position && stopPositions.has(position)) {
-            const spacePixel = getCrispLineCoordinate(getSpacePixel(position), ctx.lineWidth);
-            ctx.beginPath();
-            if (!swapAxis) {
-              ctx.moveTo(getTimePixel(prevTime), spacePixel);
-              ctx.lineTo(getTimePixel(time), spacePixel);
-            } else {
-              ctx.moveTo(spacePixel, getTimePixel(prevTime));
-              ctx.lineTo(spacePixel, getTimePixel(time));
-            }
-            ctx.stroke();
+            // Detect flat steps, and draw two graduations if any (one on each side of the step):
+            getSpacePixels(getSpacePixel, position).forEach((rawPixel) => {
+              const spacePixel = getCrispLineCoordinate(rawPixel, ctx.lineWidth);
+              ctx.beginPath();
+              if (!swapAxis) {
+                ctx.moveTo(getTimePixel(prevTime), spacePixel);
+                ctx.lineTo(getTimePixel(time), spacePixel);
+              } else {
+                ctx.moveTo(spacePixel, getTimePixel(prevTime));
+                ctx.lineTo(spacePixel, getTimePixel(time));
+              }
+              ctx.stroke();
+            });
           }
         }
       });

--- a/ui-spacetimechart/src/components/SpaceGraduations.tsx
+++ b/ui-spacetimechart/src/components/SpaceGraduations.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useDraw } from '../hooks/useCanvas';
 import { type DrawingFunction } from '../lib/types';
 import { getCrispLineCoordinate } from '../utils/canvas';
+import { getSpacePixels } from '../utils/paths';
 
 const SpaceGraduations = () => {
   const drawingFunction = useCallback<DrawingFunction>(
@@ -33,17 +34,20 @@ const SpaceGraduations = () => {
           ctx.lineDashOffset = -timePixelOffset;
         }
 
-        const spacePixel = getCrispLineCoordinate(getSpacePixel(point.position), ctx.lineWidth);
+        // Detect flat steps, and draw two graduations if any (one on each side of the step):
+        getSpacePixels(getSpacePixel, point.position).forEach((rawPixel) => {
+          const spacePixel = getCrispLineCoordinate(rawPixel, ctx.lineWidth);
 
-        ctx.beginPath();
-        if (!swapAxis) {
-          ctx.moveTo(0, spacePixel);
-          ctx.lineTo(axisSize, spacePixel);
-        } else {
-          ctx.moveTo(spacePixel, 0);
-          ctx.lineTo(spacePixel, axisSize);
-        }
-        ctx.stroke();
+          ctx.beginPath();
+          if (!swapAxis) {
+            ctx.moveTo(0, spacePixel);
+            ctx.lineTo(axisSize, spacePixel);
+          } else {
+            ctx.moveTo(spacePixel, 0);
+            ctx.lineTo(spacePixel, axisSize);
+          }
+          ctx.stroke();
+        });
       });
 
       ctx.setLineDash([]);

--- a/ui-spacetimechart/src/hooks/useCanvas.ts
+++ b/ui-spacetimechart/src/hooks/useCanvas.ts
@@ -200,6 +200,7 @@ export function useCanvas(
       if (!canvases[layerId]) {
         const canvas = document.createElement('CANVAS') as HTMLCanvasElement;
         const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
+        canvas.classList.add(`layer-${type}-${layer}`);
         canvas.style.position = 'absolute';
         canvas.style.inset = '0';
         dom.appendChild(canvas);

--- a/ui-spacetimechart/src/lib/types.ts
+++ b/ui-spacetimechart/src/lib/types.ts
@@ -91,7 +91,7 @@ export type Direction = 'forward' | 'backward' | 'still';
 
 // DATA TRANSLATION TYPES:
 export type TimeToPixel = (time: number) => number;
-export type SpaceToPixel = (position: number) => number;
+export type SpaceToPixel = (position: number, fromEnd?: boolean) => number;
 export type PixelToTime = (x: number) => number;
 export type PixelToSpace = (y: number) => number;
 export type PointToData = (point: Point) => DataPoint;
@@ -100,7 +100,7 @@ export type DataToPoint = (data: DataPoint) => Point;
 // CANVAS SPECIFIC TYPES:
 export const PICKING_LAYERS = ['paths'] as const;
 export type PickingLayerType = (typeof PICKING_LAYERS)[number];
-export const LAYERS = ['background', 'graduations', 'paths', 'captions', 'overlay'] as const;
+export const LAYERS = ['background', 'graduations', 'paths', 'overlay', 'captions'] as const;
 export type LayerType = (typeof LAYERS)[number];
 
 // PICKING SPECIFIC TYPES:

--- a/ui-spacetimechart/src/lib/types.ts
+++ b/ui-spacetimechart/src/lib/types.ts
@@ -87,6 +87,8 @@ export type OperationalPoint = {
 
 export type Axis = 'x' | 'y';
 
+export type Direction = 'forward' | 'backward' | 'still';
+
 // DATA TRANSLATION TYPES:
 export type TimeToPixel = (time: number) => number;
 export type SpaceToPixel = (position: number) => number;

--- a/ui-spacetimechart/src/stories/lib/paths.ts
+++ b/ui-spacetimechart/src/stories/lib/paths.ts
@@ -121,6 +121,8 @@ const REVERSED_BACK_AND_FORTH_POINTS = [
 
 export const START_DATE = new Date('2024/04/02');
 
+// TODO:
+// Store and share the hardcoded colors with other stories that use the GET as well
 export const PATHS: (PathData & { color: string })[] = [
   // Omnibuses:
   ...getPaths(

--- a/ui-spacetimechart/src/stories/lib/paths.ts
+++ b/ui-spacetimechart/src/stories/lib/paths.ts
@@ -1,4 +1,6 @@
-import { type OperationalPoint, type PathData } from '../../lib/types';
+import { keyBy } from 'lodash';
+
+import type { OperationalPoint, PathData } from '../../lib/types';
 
 const KM = 1000;
 const MIN = 60 * 1000;
@@ -13,6 +15,7 @@ export function getPaths<T extends object>(
   t0: number,
   additionalAttributes: T
 ): (PathData & T)[] {
+  speed = Math.abs(speed);
   const res: (PathData & T)[] = [];
 
   for (let i = 0; i < count; i++) {
@@ -35,7 +38,7 @@ export function getPaths<T extends object>(
         const previousPoint = points[index - 1];
         // Travel:
         const travelDistance = point.position - previousPoint.position;
-        const travelTime = travelDistance / speed;
+        const travelTime = Math.abs(travelDistance) / speed;
         p += travelDistance;
         t += travelTime;
         path.points.push({
@@ -96,10 +99,25 @@ export const OPERATIONAL_POINTS: OperationalPoint[] = [
     importanceLevel: 1,
   },
 ];
+export const OPERATIONAL_POINTS_DICT = keyBy(OPERATIONAL_POINTS, 'id');
 
 const REVERSED_POINTS = OPERATIONAL_POINTS.slice(0).reverse();
 const EXTREME_POINTS = [OPERATIONAL_POINTS[0], OPERATIONAL_POINTS[2], OPERATIONAL_POINTS[5]];
 const REVERSED_EXTREME_POINTS = EXTREME_POINTS.slice(0).reverse();
+const BACK_AND_FORTH_POINTS = [
+  OPERATIONAL_POINTS_DICT['city-b'],
+  OPERATIONAL_POINTS_DICT['city-d'],
+  OPERATIONAL_POINTS_DICT['city-e'],
+  OPERATIONAL_POINTS_DICT['city-d'],
+  OPERATIONAL_POINTS_DICT['city-b'],
+];
+const REVERSED_BACK_AND_FORTH_POINTS = [
+  OPERATIONAL_POINTS_DICT['city-e'],
+  OPERATIONAL_POINTS_DICT['city-d'],
+  OPERATIONAL_POINTS_DICT['city-b'],
+  OPERATIONAL_POINTS_DICT['city-d'],
+  OPERATIONAL_POINTS_DICT['city-e'],
+];
 
 export const START_DATE = new Date('2024/04/02');
 
@@ -120,7 +138,7 @@ export const PATHS: (PathData & { color: string })[] = [
     REVERSED_POINTS,
     3 * MIN,
     35 * MIN,
-    -(80 * KM) / (60 * MIN),
+    (80 * KM) / (60 * MIN),
     4,
     +START_DATE,
     { color: '#FF8E3D' }
@@ -137,9 +155,31 @@ export const PATHS: (PathData & { color: string })[] = [
     REVERSED_EXTREME_POINTS,
     5 * MIN,
     45 * MIN,
-    -(140 * KM) / (60 * MIN),
+    (140 * KM) / (60 * MIN),
     3,
     +START_DATE,
     { color: '#66C0F1', fromEnd: 'out', toEnd: 'out' }
+  ),
+
+  // Back and forth trains:
+  ...getPaths(
+    'back-and-forth',
+    BACK_AND_FORTH_POINTS,
+    10 * MIN,
+    30 * MIN,
+    (80 * KM) / (60 * MIN),
+    2,
+    +START_DATE + 15 * MIN,
+    { color: '#286109', toEnd: 'out' }
+  ),
+  ...getPaths(
+    'back-and-forth-reversed',
+    REVERSED_BACK_AND_FORTH_POINTS,
+    12 * MIN,
+    30 * MIN,
+    (80 * KM) / (60 * MIN),
+    2,
+    +START_DATE + 3 * MIN,
+    { color: '#64cc2b', toEnd: 'out' }
   ),
 ];

--- a/ui-spacetimechart/src/stories/performances.stories.tsx
+++ b/ui-spacetimechart/src/stories/performances.stories.tsx
@@ -68,7 +68,7 @@ const Wrapper = ({
         isOmnibus ? (isReversed ? reversedAllOP : allOP) : isReversed ? reversedMainOP : mainOP,
         5 * MINUTE,
         (30 + trainTypeIndex * 5) * MINUTE,
-        speed * (isReversed ? -1 : 1),
+        speed,
         pathsPerTrain,
         DATE_OFFSET,
         {

--- a/ui-spacetimechart/src/stories/split.stories.tsx
+++ b/ui-spacetimechart/src/stories/split.stories.tsx
@@ -1,0 +1,204 @@
+import React, { useCallback, useMemo, useState } from 'react';
+
+import '@osrd-project/ui-core/dist/theme.css';
+
+import type { Meta } from '@storybook/react';
+import { clamp, keyBy } from 'lodash';
+
+import { OPERATIONAL_POINTS, PATHS } from './lib/paths';
+import { PathLayer } from '../components/PathLayer';
+import { SpaceTimeChart } from '../components/SpaceTimeChart';
+import type { DrawingFunction, Point } from '../lib/types';
+import { getDiff } from '../utils/vectors';
+import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom } from './lib/utils';
+import { useDraw } from '../hooks/useCanvas';
+import { AMBIANT_A10 } from '../lib/consts';
+
+const COEFFICIENT = 300;
+
+/**
+ * This component renders a colored area where the line only has one track:
+ */
+const FlatStep = ({ position }: { position: number }) => {
+  const drawMonoTrackSpace = useCallback<DrawingFunction>(
+    (ctx, { getSpacePixel, width, height, spaceAxis }) => {
+      const spaceSize = spaceAxis === 'x' ? width : height;
+      const timeSize = spaceAxis === 'x' ? height : width;
+      const fromPixel = clamp(getSpacePixel(position), 0, spaceSize);
+      const toPixel = clamp(getSpacePixel(position, true), 0, spaceSize);
+      const monoLineSize = toPixel - fromPixel;
+      if (!monoLineSize) return;
+
+      ctx.fillStyle = AMBIANT_A10;
+      if (spaceAxis === 'x') {
+        ctx.fillRect(fromPixel, 0, monoLineSize, timeSize);
+      } else {
+        ctx.fillRect(0, fromPixel, timeSize, monoLineSize);
+      }
+    },
+    [position]
+  );
+
+  useDraw('overlay', drawMonoTrackSpace);
+
+  return null;
+};
+
+type WrapperProps = {
+  splitPoints: string;
+  splitHeight: number;
+  scaleWithZoom: boolean;
+  swapAxis: boolean;
+};
+
+const SplitSpaceTimeChartWrapper = ({
+  splitPoints,
+  splitHeight,
+  scaleWithZoom,
+  swapAxis,
+}: WrapperProps) => {
+  const [state, setState] = useState<{
+    xOffset: number;
+    yOffset: number;
+    xZoomLevel: number;
+    yZoomLevel: number;
+    panning: null | { initialOffset: Point };
+  }>({
+    xOffset: 0,
+    yOffset: 0,
+    xZoomLevel: X_ZOOM_LEVEL,
+    yZoomLevel: Y_ZOOM_LEVEL,
+    panning: null,
+  });
+
+  // For this story, we split the chart on "City C" and "City E:
+  const fullSplitPoints = useMemo(() => {
+    const operationalPointsDict = keyBy(OPERATIONAL_POINTS, 'id');
+    const splitPointsSet = new Set(splitPoints.split(','));
+    return 'ABCDEF'
+      .split('')
+      .filter((letter) => splitPointsSet.has(letter))
+      .map((letter) => ({
+        position: operationalPointsDict[`city-${letter.toLowerCase()}`].position,
+        label: operationalPointsDict[`city-${letter.toLowerCase()}`].label,
+        height: scaleWithZoom ? splitHeight * state.yZoomLevel : splitHeight,
+      }));
+  }, [scaleWithZoom, splitHeight, splitPoints, state.yZoomLevel]);
+
+  const spaceScales = useMemo(
+    () =>
+      fullSplitPoints
+        .flatMap(({ position, height }) => [
+          {
+            to: position,
+            coefficient: COEFFICIENT / state.yZoomLevel,
+          },
+          {
+            to: position,
+            size: height,
+          },
+        ])
+        .concat({
+          to: OPERATIONAL_POINTS.at(-1)!.position,
+          coefficient: COEFFICIENT / state.yZoomLevel,
+        }),
+    [fullSplitPoints, state.yZoomLevel]
+  );
+
+  return (
+    <div className="absolute inset-0">
+      <SpaceTimeChart
+        className="h-full"
+        spaceOrigin={0}
+        swapAxis={swapAxis}
+        xOffset={state.xOffset}
+        yOffset={state.yOffset}
+        timeOrigin={+new Date('2024/04/02')}
+        operationalPoints={OPERATIONAL_POINTS}
+        timeScale={100000 / state.xZoomLevel}
+        spaceScales={spaceScales}
+        onPan={({ initialPosition, position, isPanning }) => {
+          const { panning } = state;
+          const diff = getDiff(initialPosition, position);
+
+          // Stop panning:
+          if (!isPanning) {
+            setState((prev) => ({
+              ...prev,
+              panning: null,
+            }));
+          }
+          // Start panning stage
+          else if (!panning) {
+            setState((prev) => ({
+              ...prev,
+              panning: {
+                initialOffset: {
+                  x: prev.xOffset,
+                  y: prev.yOffset,
+                },
+              },
+            }));
+          }
+          // Keep panning stage:
+          else {
+            const xOffset = panning.initialOffset.x + diff.x;
+            const yOffset = panning.initialOffset.y + diff.y;
+
+            setState((prev) => ({
+              ...prev,
+              xOffset,
+              yOffset,
+            }));
+          }
+        }}
+        onZoom={(payload) => {
+          setState((prev) => ({
+            ...prev,
+            ...zoom(state, payload),
+          }));
+        }}
+      >
+        {PATHS.map((path) => (
+          <PathLayer key={path.id} path={path} color={path.color} />
+        ))}
+        {fullSplitPoints.map(({ position }, i) => (
+          <FlatStep key={i} position={position} />
+        ))}
+      </SpaceTimeChart>
+    </div>
+  );
+};
+
+export default {
+  title: 'SpaceTimeChart/Split',
+  component: SplitSpaceTimeChartWrapper,
+  argTypes: {
+    splitPoints: {
+      name: 'Operational points to split on (pick in A, B, C, D, E and F, separate with commas)',
+      control: { type: 'text' },
+    },
+    splitHeight: {
+      name: 'Split steps height (in pixels)',
+      control: { type: 'number' },
+    },
+    scaleWithZoom: {
+      name: 'Scale split steps with zoom?',
+      control: { type: 'boolean' },
+    },
+    swapAxis: {
+      name: 'Swap time and space axis?',
+      control: { type: 'boolean' },
+    },
+  },
+} as Meta<typeof SplitSpaceTimeChartWrapper>;
+
+export const Default = {
+  name: 'Default arguments',
+  args: {
+    splitPoints: 'A,C,E',
+    splitHeight: 100,
+    scaleWithZoom: false,
+    swapAxis: false,
+  },
+};

--- a/ui-spacetimechart/src/utils/canvas.ts
+++ b/ui-spacetimechart/src/utils/canvas.ts
@@ -1,6 +1,6 @@
 import { clamp, identity } from 'lodash';
 
-import { type PathEnd, type Point, type RGBAColor, type RGBColor } from '../lib/types';
+import type { Direction, PathEnd, Point, RGBAColor, RGBColor } from '../lib/types';
 
 /**
  * This function draws a thick lines from "from" to "to" on the given ImageData, with no
@@ -228,10 +228,10 @@ export function drawPathOutExtremity(
   spacePixel: number,
   swapAxis: boolean,
   extremityType: 'from' | 'to',
-  pathDirection: 'up' | 'down'
+  pathDirection: Direction
 ): void {
   let horizontalSign = extremityType === 'from' ? -1 : 1;
-  let verticalSign = (pathDirection === 'down' ? -1 : 1) * horizontalSign;
+  let verticalSign = (pathDirection === 'backward' ? -1 : 1) * horizontalSign;
   let controlX = timePixel + 4 * horizontalSign;
   let controlY = spacePixel + (OUT_END_SIZE - 2) * verticalSign;
   let x = timePixel;
@@ -264,7 +264,7 @@ export function drawPathExtremity(
   spacePixel: number,
   swapAxis: boolean,
   extremityType: 'from' | 'to',
-  pathDirection: 'up' | 'down',
+  pathDirection: Direction,
   pathEnd: PathEnd
 ): void {
   if (pathEnd === 'out') {

--- a/ui-spacetimechart/src/utils/paths.ts
+++ b/ui-spacetimechart/src/utils/paths.ts
@@ -1,4 +1,4 @@
-import type { DataPoint, Direction, PathData } from '../lib/types';
+import type { DataPoint, Direction, PathData, SpaceToPixel } from '../lib/types';
 
 /**
  * This function takes a path, a point index and looks forward in the points order for the first
@@ -28,4 +28,21 @@ export function getPathDirection(
   }
 
   return 'still';
+}
+
+/**
+ * This function takes a SpaceToPixel function and a position, and checks if the function returns
+ * the same pixel for the position, starting from both sides. It then returns one or two pixel
+ * positions accordingly.
+ */
+export function getSpacePixels(
+  getSpacePixel: SpaceToPixel,
+  position: number
+): [number] | [number, number] {
+  const spacePixelFromStart = getSpacePixel(position);
+  const spacePixelFromEnd = getSpacePixel(position, true);
+
+  return spacePixelFromStart === spacePixelFromEnd
+    ? [spacePixelFromStart]
+    : [spacePixelFromStart, spacePixelFromEnd];
 }

--- a/ui-spacetimechart/src/utils/paths.ts
+++ b/ui-spacetimechart/src/utils/paths.ts
@@ -1,0 +1,31 @@
+import type { DataPoint, Direction, PathData } from '../lib/types';
+
+/**
+ * This function takes a path, a point index and looks forward in the points order for the first
+ * position variation. It then returns "forward" or "backward" according to that variation.
+ *
+ * If it does not find any variation for some reason, it returns "still" instead.
+ *
+ * Finally, if `reversed` is true, then, it searches points in the other direction.
+ */
+export function getPathDirection(
+  { points }: PathData,
+  index: number,
+  reversed?: boolean
+): Direction {
+  if (points.length < 2 || !points[index]) return 'still';
+
+  const reference = points[index].position;
+  let i = index;
+  let point: DataPoint | undefined;
+  while ((point = points[i])) {
+    if (point.position !== reference) {
+      const delta = reversed ? reference - point.position : point.position - reference;
+      return delta > 0 ? 'forward' : 'backward';
+    }
+
+    i = i + (reversed ? -1 : 1);
+  }
+
+  return 'still';
+}

--- a/ui-spacetimechart/src/utils/scales.ts
+++ b/ui-spacetimechart/src/utils/scales.ts
@@ -107,17 +107,26 @@ export function spaceScalesToBinaryTree(
  *
  * Also, if the position is lower than the tree's min (tree.from), then the first leaf is returned
  * and if it is higher than the max (tree.to), the last leaf is returned.
+ *
+ * Finally, if pickLast is truthy, then it returns the last leaf node that contains that position
+ * instead of the first one. It is very important when there are flat sections.
  */
 export function getNormalizedScaleAtPosition(
   position: number,
-  tree: NormalizedScaleTree
+  tree: NormalizedScaleTree,
+  pickLast?: boolean
 ): NormalizedScale {
   position = clamp(position, tree.from, tree.to);
 
   let node = tree;
   while ('limit' in node) {
-    if (position <= node.limit) node = node.left;
-    else node = node.right;
+    if (!pickLast) {
+      if (position <= node.limit) node = node.left;
+      else node = node.right;
+    } else {
+      if (position >= node.limit) node = node.right;
+      else node = node.left;
+    }
   }
   return node;
 }
@@ -162,8 +171,12 @@ export function getSpaceToPixel(
   pixelOffset: number,
   binaryTree: NormalizedScaleTree
 ): SpaceToPixel {
-  return (position: number) => {
-    const { from, pixelFrom, coefficient } = getNormalizedScaleAtPosition(position, binaryTree);
+  return (position: number, fromEnd?: boolean) => {
+    const { from, pixelFrom, coefficient } = getNormalizedScaleAtPosition(
+      position,
+      binaryTree,
+      fromEnd
+    );
     return pixelOffset + pixelFrom + (position - from) / coefficient;
   };
 }
@@ -243,11 +256,9 @@ export function getSpaceBreakpoints(from: number, to: number, tree: NormalizedSc
   to = Math.min(to, tree.to);
 
   let fromScale = getNormalizedScaleAtPosition(from, tree) as NormalizedScale;
-  let lastValue = from;
   const res: number[] = [];
   while (fromScale.to < to) {
-    if (fromScale.to !== lastValue) res.push(fromScale.to);
-    lastValue = fromScale.to;
+    res.push(fromScale.to);
     fromScale = fromScale.next as NormalizedScale;
   }
 


### PR DESCRIPTION
This pull request addresses issue osrd-project/osrd-confidential#870.

It allows giving a SpaceTimeChart **flat steps**, i.e. `SpaceScales` with a `to` value equal to the previous one's (where the chart is effectively split). Then, it adds a story that combines flat steps with a custom layer, to overdraw flat steps with a custom component.

Details:
- Adds back-and-forth trains in stories
- Improves and fixes `getPathDirection`, to handle trains that change directions
- Updates `getSpaceBreakpoints` to no more deduplicate repeated values, which allows easily detecting flat steps
- Updates `getNormalizedScaleAtPosition` and `getSpaceToPixel` to allow retrieving both sides of the flat steps
- Fixes `getPathSegments` with flat steps
- Updates space graduations and path pauses rendering, so that they are rendered on both sides of the flat steps
- Adds a story to showcase all this