### PR TITLE
ui-charts: add zoom rectangle (part 3)

### DIFF
--- a/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/base-with-waypoint-menu.stories.tsx
+++ b/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/base-with-waypoint-menu.stories.tsx
@@ -68,12 +68,13 @@ const ManchetteWithSpaceTimeWrapper = ({
     setActiveWaypointId(waypointId);
   };
 
-  const { manchetteProps, spaceTimeChartProps, handleScroll } = useManchetteWithSpaceTimeChart(
+  const { manchetteProps, spaceTimeChartProps, handleScroll } = useManchetteWithSpaceTimeChart({
     waypoints,
     projectPathTrainResult,
     manchetteWithSpaceTimeChartRef,
-    selectedTrain
-  );
+    selectedTrain,
+    defaultTimeOrigin: Math.min(...projectPathTrainResult.map((p) => +p.departureTime)),
+  });
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -142,8 +143,6 @@ const ManchetteWithSpaceTimeWrapper = ({
         >
           <SpaceTimeChart
             className="inset-0 absolute h-full"
-            spaceOrigin={0}
-            timeOrigin={Math.min(...projectPathTrainResult.map((p) => +p.departureTime))}
             {...spaceTimeChartProps}
             onPan={activeWaypointId ? undefined : spaceTimeChartProps.onPan}
           >

--- a/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/rectangle-zoom.stories.tsx
+++ b/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/rectangle-zoom.stories.tsx
@@ -1,7 +1,5 @@
 import React, { useRef } from 'react';
 
-import '@osrd-project/ui-core/dist/theme.css';
-import '@osrd-project/ui-charts/dist/theme.css';
 import {
   PathLayer,
   SpaceTimeChart,
@@ -9,10 +7,19 @@ import {
   useManchetteWithSpaceTimeChart,
   type ProjectPathTrainResult,
   type Waypoint,
+  ZoomRect,
+  MouseTracker,
 } from '@osrd-project/ui-charts';
+import { Slider } from '@osrd-project/ui-core';
+import { ZoomIn } from '@osrd-project/ui-icons';
 import type { Meta } from '@storybook/react';
+import cx from 'classnames';
 
 import { SAMPLE_WAYPOINTS, SAMPLE_PATHS_DATA } from './assets/sampleData';
+
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
+import '../../../styles/ManchetteWithSpaceTimeChart/rectangle-zoom.css';
 
 type ManchetteWithSpaceTimeWrapperProps = {
   waypoints: Waypoint[];
@@ -28,12 +35,24 @@ const ManchetteWithSpaceTimeWrapper = ({
   selectedTrain,
 }: ManchetteWithSpaceTimeWrapperProps) => {
   const manchetteWithSpaceTimeChartRef = useRef<HTMLDivElement>(null);
-
-  const { manchetteProps, spaceTimeChartProps, handleScroll } = useManchetteWithSpaceTimeChart({
+  const spaceTimeChartRef = useRef<HTMLDivElement>(null);
+  const {
+    manchetteProps,
+    spaceTimeChartProps,
+    handleScroll,
+    toggleZoomMode,
+    zoomMode,
+    xZoom,
+    handleXZoom,
+    timeScale,
+    spaceScale,
+  } = useManchetteWithSpaceTimeChart({
     waypoints,
     projectPathTrainResult,
     manchetteWithSpaceTimeChartRef,
     selectedTrain,
+    height: DEFAULT_HEIGHT,
+    spaceTimeChartRef,
     defaultTimeOrigin: Math.min(...projectPathTrainResult.map((p) => +p.departureTime)),
   });
 
@@ -42,7 +61,7 @@ const ManchetteWithSpaceTimeWrapper = ({
       <div
         className="header bg-ambientB-5 w-full border-b border-grey-30"
         style={{ height: '40px' }}
-      ></div>
+      />
       <div
         ref={manchetteWithSpaceTimeChartRef}
         className="manchette flex"
@@ -52,21 +71,52 @@ const ManchetteWithSpaceTimeWrapper = ({
         <Manchette {...manchetteProps} />
         <div
           className="space-time-chart-container w-full sticky"
+          ref={spaceTimeChartRef}
           style={{ bottom: 0, left: 0, top: 2, height: `${DEFAULT_HEIGHT - 6}px` }}
         >
-          <SpaceTimeChart className="inset-0 absolute h-full" {...spaceTimeChartProps}>
+          <div className="toolbar">
+            <button
+              type="button"
+              className={cx('zoom-button', { 'zoom-button-clicked': zoomMode })}
+              onClick={toggleZoomMode}
+            >
+              <ZoomIn className="icon" />
+            </button>
+          </div>
+          <SpaceTimeChart
+            className={cx('inset-0', 'absolute', 'h-full', {
+              'space-time-chart-zoom-mode': zoomMode,
+            })}
+            {...spaceTimeChartProps}
+          >
             {spaceTimeChartProps.paths.map((path) => (
               <PathLayer key={path.id} path={path} color={path.color} level={path.level} />
             ))}
+            {spaceTimeChartProps.rect && <ZoomRect {...spaceTimeChartProps.rect} />}
+            <MouseTracker />
           </SpaceTimeChart>
         </div>
+      </div>
+      <div className="bottom-controls">
+        <div className="scales">
+          <div>time scale: {timeScale.toFixed(0)} ms/px</div>
+          <div>space scale: {spaceScale.toFixed(0)} mm/px</div>
+        </div>
+        <Slider
+          containerClassName="space-time-h-slider-container"
+          className="space-time-h-slider"
+          value={xZoom}
+          onChange={(e) => {
+            handleXZoom(Number(e.target.value));
+          }}
+        />
       </div>
     </div>
   );
 };
 
 const meta: Meta<typeof ManchetteWithSpaceTimeWrapper> = {
-  title: 'Manchette with SpaceTimeChart/rendering',
+  title: 'Manchette with SpaceTimeChart/Zoom rectangle',
   component: ManchetteWithSpaceTimeWrapper,
 };
 

--- a/storybook/styles/ManchetteWithSpaceTimeChart/rectangle-zoom.css
+++ b/storybook/styles/ManchetteWithSpaceTimeChart/rectangle-zoom.css
@@ -1,0 +1,68 @@
+.manchette-space-time-chart-wrapper {
+  .space-time-chart-container {
+    .space-time-chart-zoom-mode {
+      cursor: crosshair;
+      user-select: none;
+    }
+  
+    .toolbar {
+      position: absolute;
+      right: 7px;
+      top: 7px;
+      z-index: 10;
+      border: 1px solid theme('colors.black.10');
+      border-radius: 5px;
+  
+      button {
+        outline: none;
+        background: theme('colors.white.100');
+        color: theme('colors.black.100');
+        padding: 5px 7px 0;
+      }
+  
+      button:not(:last-child) {
+        border-radius: 5px 0 0 5px;
+        border-right: 1px solid theme('colors.black.10');
+      }
+  
+      button:last-child {
+        border-radius: 5px;
+      }
+  
+      .zoom-button {
+        .icon {
+          display: inline-block;
+        }
+  
+        &:hover {
+          background-color: theme('colors.primary.5');
+        }
+      }
+  
+      .zoom-button-clicked {
+        background-color: theme('colors.primary.90');
+  
+        .icon {
+          color: theme('colors.white.100');
+        }
+  
+        &:hover {
+          background-color: theme('colors.primary.90');
+        }
+      }
+    }
+  }
+
+  .bottom-controls {
+    position: absolute;
+    display: flex;
+    width: 100%;
+    bottom: -60px;
+    .space-time-h-slider-container {
+      position: absolute;
+      right: 24px;
+
+      z-index: 10;
+    }
+  }
+}

--- a/ui-charts/src/manchette/components/ManchetteWithSpaceTimeChart.tsx
+++ b/ui-charts/src/manchette/components/ManchetteWithSpaceTimeChart.tsx
@@ -35,14 +35,15 @@ const ManchetteWithSpaceTimeChart = ({
   const manchetteWithSpaceTimeChartRef = useRef<HTMLDivElement>(null);
   const spaceTimeChartRef = useRef<HTMLDivElement>(null);
 
-  const { manchetteProps, spaceTimeChartProps, handleScroll } = useManchetteWithSpaceTimeChart(
+  const { manchetteProps, spaceTimeChartProps, handleScroll } = useManchetteWithSpaceTimeChart({
     waypoints,
     projectPathTrainResult,
     manchetteWithSpaceTimeChartRef,
     selectedTrain,
     height,
-    spaceTimeChartRef
-  );
+    spaceTimeChartRef,
+    defaultTimeOrigin: Math.min(...projectPathTrainResult.map((p) => +p.departureTime)),
+  });
 
   return (
     <div className="manchette-space-time-chart-wrapper">
@@ -66,8 +67,6 @@ const ManchetteWithSpaceTimeChart = ({
         >
           <SpaceTimeChart
             className="inset-0 absolute h-full"
-            spaceOrigin={0}
-            timeOrigin={Math.min(...projectPathTrainResult.map((p) => +p.departureTime))}
             {...spaceTimeChartProps}
             {...additionalSpaceTimeChartProps}
           >

--- a/ui-charts/src/manchette/consts.ts
+++ b/ui-charts/src/manchette/consts.ts
@@ -4,15 +4,16 @@ export const BASE_WAYPOINT_HEIGHT = 32;
 export const INITIAL_WAYPOINT_LIST_HEIGHT = 521;
 export const INITIAL_SPACE_TIME_CHART_HEIGHT = INITIAL_WAYPOINT_LIST_HEIGHT + 40;
 
-export const MIN_ZOOM_MS_PER_PX = 600000;
+export const MIN_ZOOM_MS_PER_PX = 600_000;
 export const MAX_ZOOM_MS_PER_PX = 625;
-export const DEFAULT_ZOOM_MS_PER_PX = 7500;
+export const DEFAULT_ZOOM_MS_PER_PX = 7_500;
 export const MIN_ZOOM_X = 0;
 export const MAX_ZOOM_X = 100;
 
 export const MIN_ZOOM_Y = 1;
 export const MAX_ZOOM_Y = 10.5;
 export const ZOOM_Y_DELTA = 0.5;
+export const MAX_ZOOM_MANCHETTE_HEIGHT_MILLIMETER = 500_000;
 
 export const FOOTER_HEIGHT = 40; // height of the manchette footer
 export const WAYPOINT_LINE_HEIGHT = 16;

--- a/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.ts
+++ b/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.ts
@@ -1,60 +1,141 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { clamp } from 'lodash';
+
 import usePaths from './usePaths';
 import type { SpaceScale, SpaceTimeChartProps } from '../../spaceTimeChart';
-import { MAX_ZOOM_Y, MIN_ZOOM_Y, ZOOM_Y_DELTA, DEFAULT_ZOOM_MS_PER_PX } from '../consts';
+import {
+  MAX_ZOOM_Y,
+  MIN_ZOOM_Y,
+  ZOOM_Y_DELTA,
+  DEFAULT_ZOOM_MS_PER_PX,
+  MAX_ZOOM_MS_PER_PX,
+  MIN_ZOOM_MS_PER_PX,
+  BASE_WAYPOINT_HEIGHT,
+  FOOTER_HEIGHT,
+  WAYPOINT_LINE_HEIGHT,
+} from '../consts';
 import type { ProjectPathTrainResult, Waypoint } from '../types';
-import { getDistance } from '../utils';
+import { getDistance, calcTotalDistance } from '../utils';
 import {
   computeWaypointsToDisplay,
   getScales,
   zoomX,
   zoomValueToTimeScale,
   timeScaleToZoomValue,
+  spaceScaleToZoomValue,
+  getExtremaScales,
+  zoomValueToSpaceScale,
 } from '../utils/helpers';
 
 type State = {
   xZoom: number;
   yZoom: number;
+  timeOrigin: number;
+  spaceOrigin: number;
+  /** current x PIXEL offset from x origin */
   xOffset: number;
-  /** the current y-scroll of the view. always updates */
+  /** current y PIXEL offset from y origin (the current y-scroll of the view. always updates) */
   yOffset: number;
   /** only update after a zoom. used to update back the view scroll value */
   scrollTo: number | null;
   panning: { initialOffset: { x: number; y: number } } | null;
+  zoomMode: boolean;
+  rect: {
+    timeStart: Date;
+    timeEnd: Date;
+    spaceStart: number; // mm
+    spaceEnd: number; // mm
+  } | null;
+  pixelRect: {
+    xStart: number;
+    xEnd: number;
+    yStart: number;
+    yEnd: number;
+  } | null;
   isProportional: boolean;
   waypointsChart: Waypoint[];
   scales: SpaceScale[];
 };
 
-const useManchettesWithSpaceTimeChart = (
-  waypoints: Waypoint[],
-  projectPathTrainResult: ProjectPathTrainResult[],
-  manchetteWithSpaceTimeChartContainer: React.RefObject<HTMLDivElement>,
-  selectedTrain?: number,
+const useManchetteWithSpaceTimeChart = ({
+  waypoints,
+  projectPathTrainResult,
+  manchetteWithSpaceTimeChartRef,
+  selectedTrain,
   height = 561,
-  spaceTimeChartRef?: React.RefObject<HTMLDivElement>
-) => {
+  spaceTimeChartRef,
+  defaultTimeOrigin = 0,
+  defaultSpaceOrigin = 0,
+}: {
+  waypoints: Waypoint[];
+  projectPathTrainResult: ProjectPathTrainResult[];
+  manchetteWithSpaceTimeChartRef: React.RefObject<HTMLDivElement>;
+  selectedTrain?: number;
+  height?: number;
+  spaceTimeChartRef?: React.RefObject<HTMLDivElement>;
+  defaultTimeOrigin?: number;
+  defaultSpaceOrigin?: number;
+}) => {
   const [isShiftPressed, setIsShiftPressed] = useState(false);
   const [state, setState] = useState<State>({
     xZoom: timeScaleToZoomValue(DEFAULT_ZOOM_MS_PER_PX),
     yZoom: 1,
+    timeOrigin: defaultTimeOrigin,
+    spaceOrigin: defaultSpaceOrigin,
     xOffset: 0,
     yOffset: 0,
     scrollTo: null,
     panning: null,
+    zoomMode: false,
+    rect: null,
+    pixelRect: null,
     isProportional: true,
     waypointsChart: [],
     scales: [],
   });
 
-  const { xZoom, yZoom, xOffset, yOffset, scrollTo, panning, isProportional } = state;
+  const {
+    xZoom,
+    yZoom,
+    timeOrigin,
+    spaceOrigin,
+    xOffset,
+    yOffset,
+    scrollTo,
+    panning,
+    zoomMode,
+    rect,
+    pixelRect,
+    isProportional,
+  } = state;
+
+  /** used when we change the train dataset for example to center the chart on the new data */
+  const setTimeOrigin = useCallback((newTimeOrigin: number) => {
+    setState((prev) => ({ ...prev, timeOrigin: newTimeOrigin }));
+  }, []);
 
   const paths = usePaths(projectPathTrainResult, selectedTrain);
+  const canvasDrawingHeight = height - FOOTER_HEIGHT; // 521
+  const drawingHeightWithoutTopPadding = canvasDrawingHeight - BASE_WAYPOINT_HEIGHT / 2; // 505
+  const drawingHeightWithoutBothPadding = canvasDrawingHeight - BASE_WAYPOINT_HEIGHT; // 489
+  const totalDistance = calcTotalDistance(waypoints);
+
+  const { minZoomMillimeterPerPx, maxZoomMillimeterPerPx } = getExtremaScales(
+    drawingHeightWithoutTopPadding,
+    drawingHeightWithoutBothPadding,
+    totalDistance
+  );
 
   const waypointsToDisplay = useMemo(
-    () => computeWaypointsToDisplay(waypoints, { height, isProportional, yZoom }),
-    [waypoints, height, isProportional, yZoom]
+    () =>
+      computeWaypointsToDisplay(
+        waypoints,
+        { height, isProportional, yZoom },
+        minZoomMillimeterPerPx,
+        maxZoomMillimeterPerPx
+      ),
+    [waypoints, height, isProportional, yZoom, minZoomMillimeterPerPx, maxZoomMillimeterPerPx]
   );
 
   const simplifiedWaypoints = useMemo(
@@ -68,54 +149,188 @@ const useManchettesWithSpaceTimeChart = (
     [waypointsToDisplay]
   );
 
-  const zoomYIn = useCallback(() => {
-    if (yZoom < MAX_ZOOM_Y) {
-      const newYZoom = yZoom + ZOOM_Y_DELTA;
-      const newYOffset = yOffset * (newYZoom / yZoom);
+  const computedScales = useMemo(
+    () =>
+      getScales(
+        simplifiedWaypoints,
+        { height, isProportional, yZoom },
+        minZoomMillimeterPerPx,
+        maxZoomMillimeterPerPx
+      ),
+    [
+      simplifiedWaypoints,
+      height,
+      isProportional,
+      yZoom,
+      minZoomMillimeterPerPx,
+      maxZoomMillimeterPerPx,
+    ]
+  );
 
-      setState((prev) => ({
-        ...prev,
-        yZoom: newYZoom,
-        yOffset: newYOffset,
-        scrollTo: newYOffset,
-      }));
-    }
-  }, [yZoom, yOffset]);
+  const handleRectangleZoom = useCallback(
+    ({
+      scales: { chosenTimeScale, chosenSpaceScale },
+      overrideState,
+    }: {
+      scales: { chosenTimeScale: number; chosenSpaceScale?: number };
+      overrideState?: Partial<State>;
+    }) => {
+      setState((prev) => {
+        if (prev.zoomMode || !prev.rect) {
+          return prev;
+        }
+        const newTimeScale = clamp(chosenTimeScale, MAX_ZOOM_MS_PER_PX, MIN_ZOOM_MS_PER_PX);
+        const timeZoomValue = timeScaleToZoomValue(newTimeScale);
+        const leftRectSide = Math.min(Number(prev.rect.timeStart), Number(prev.rect.timeEnd));
+        const newXOffset = (timeOrigin - leftRectSide) / newTimeScale;
 
-  const zoomYOut = useCallback(() => {
-    if (yZoom > MIN_ZOOM_Y) {
-      const newYZoom = yZoom - ZOOM_Y_DELTA;
-      const newYOffset = yOffset * (newYZoom / yZoom);
-      setState((prev) => ({
-        ...prev,
-        yZoom: newYZoom,
-        yOffset: newYOffset,
-        scrollTo: newYOffset,
-      }));
-    }
-  }, [yZoom, yOffset]);
+        let newYZoom = yZoom;
+        let newYOffset = yOffset;
+        if (chosenSpaceScale) {
+          const newSpaceScale = clamp(
+            chosenSpaceScale,
+            maxZoomMillimeterPerPx,
+            minZoomMillimeterPerPx
+          );
+          newYZoom = spaceScaleToZoomValue(
+            minZoomMillimeterPerPx,
+            maxZoomMillimeterPerPx,
+            newSpaceScale
+          );
+          const topRectSide = Math.min(prev.rect.spaceStart, prev.rect.spaceEnd);
+          newYOffset = Math.abs(spaceOrigin - topRectSide) / newSpaceScale;
+        }
+
+        return {
+          ...prev,
+          xZoom: timeZoomValue,
+          yZoom: newYZoom,
+          xOffset: newXOffset,
+          yOffset: newYOffset,
+          scrollTo: newYOffset,
+          ...overrideState,
+        };
+      });
+    },
+    [timeOrigin, spaceOrigin, minZoomMillimeterPerPx, maxZoomMillimeterPerPx, yOffset, yZoom]
+  );
 
   useEffect(() => {
-    if (scrollTo !== null && manchetteWithSpaceTimeChartContainer.current) {
-      manchetteWithSpaceTimeChartContainer.current.scrollTo({
+    if (rect && !zoomMode && spaceTimeChartRef?.current) {
+      const { timeStart, timeEnd, spaceStart, spaceEnd } = rect;
+      const timeRange = Math.abs(Number(timeEnd) - Number(timeStart)); // width of rect in ms
+      const spaceRange = Math.abs(spaceEnd - spaceStart); // height of rect in mm
+
+      const chosenTimeScale = timeRange / spaceTimeChartRef.current.clientWidth;
+      if (isProportional) {
+        const chosenSpaceScale = spaceRange / drawingHeightWithoutTopPadding;
+        handleRectangleZoom({
+          scales: { chosenTimeScale, chosenSpaceScale },
+          overrideState: { rect: null },
+        });
+      } else if (pixelRect) {
+        const currentStopHeight = BASE_WAYPOINT_HEIGHT * yZoom;
+        const { yStart, yEnd } = pixelRect;
+        const numberOfStopsInRect = Math.abs(yEnd - yStart) / currentStopHeight;
+        let newStopHeight = drawingHeightWithoutTopPadding / numberOfStopsInRect;
+        // at maximum zoom, we want 3 stops displayed
+        const maxStopHeight =
+          drawingHeightWithoutTopPadding / (2 + BASE_WAYPOINT_HEIGHT / newStopHeight);
+        newStopHeight = Math.min(newStopHeight, maxStopHeight);
+        const newYZoom = newStopHeight / BASE_WAYPOINT_HEIGHT;
+        const rectTop = yOffset + Math.min(yStart, yEnd) - WAYPOINT_LINE_HEIGHT;
+        const numberOfStopsBeforeRectTop = rectTop / currentStopHeight;
+        const newYOffset = numberOfStopsBeforeRectTop * newStopHeight;
+
+        handleRectangleZoom({
+          scales: {
+            chosenTimeScale,
+          },
+          overrideState: {
+            rect: null,
+            pixelRect: null,
+            yZoom: newYZoom,
+            yOffset: newYOffset,
+            scrollTo: newYOffset,
+          },
+        });
+      }
+    }
+  }, [
+    state.rect,
+    state.zoomMode,
+    handleRectangleZoom,
+    drawingHeightWithoutTopPadding,
+    isProportional,
+    pixelRect,
+    rect,
+    spaceTimeChartRef,
+    yOffset,
+    yZoom,
+    zoomMode,
+  ]);
+
+  const zoomYIn = useCallback(() => {
+    const maxZoom = isProportional
+      ? MAX_ZOOM_Y
+      : (drawingHeightWithoutTopPadding - BASE_WAYPOINT_HEIGHT) / (2 * BASE_WAYPOINT_HEIGHT);
+    const newYZoom = Math.min(yZoom + ZOOM_Y_DELTA, maxZoom);
+    if (newYZoom !== yZoom) {
+      const newYOffset = yOffset * (newYZoom / yZoom);
+
+      setState((prev) => ({
+        ...prev,
+        yZoom: newYZoom,
+        yOffset: newYOffset,
+        scrollTo: newYOffset,
+      }));
+    }
+  }, [yZoom, yOffset, drawingHeightWithoutTopPadding, isProportional]);
+
+  const zoomYOut = useCallback(() => {
+    const newYZoom = Math.max(MIN_ZOOM_Y, yZoom - ZOOM_Y_DELTA);
+    if (newYZoom !== yZoom) {
+      const newYOffset = yOffset * (newYZoom / yZoom);
+      setState((prev) => ({
+        ...prev,
+        yZoom: newYZoom,
+        yOffset: newYOffset,
+        scrollTo: newYOffset,
+      }));
+    }
+  }, [yZoom, yOffset]);
+
+  const handleXZoom = useCallback(
+    (newXZoom: number, xPosition = (spaceTimeChartRef?.current?.offsetWidth || 0) / 2) => {
+      setState((prev) => ({
+        ...prev,
+        ...zoomX(prev.xZoom, prev.xOffset, newXZoom, xPosition),
+      }));
+    },
+    [spaceTimeChartRef]
+  );
+
+  useEffect(() => {
+    if (scrollTo !== null && manchetteWithSpaceTimeChartRef.current) {
+      manchetteWithSpaceTimeChartRef.current.scrollTo({
         top: scrollTo,
         behavior: 'instant',
       });
     }
-  }, [scrollTo, manchetteWithSpaceTimeChartContainer]);
+  }, [scrollTo, manchetteWithSpaceTimeChartRef]);
 
   const resetZoom = useCallback(() => {
     setState((prev) => ({ ...prev, yZoom: 1 }));
   }, []);
 
   const handleScroll = useCallback(() => {
-    if (!isShiftPressed && manchetteWithSpaceTimeChartContainer.current) {
-      const { scrollTop } = manchetteWithSpaceTimeChartContainer.current;
+    if (!isShiftPressed && manchetteWithSpaceTimeChartRef.current) {
+      const { scrollTop } = manchetteWithSpaceTimeChartRef.current;
       if (scrollTop || scrollTop === 0) {
         setState((prev) => ({ ...prev, yOffset: scrollTop }));
       }
     }
-  }, [isShiftPressed, manchetteWithSpaceTimeChartContainer]);
+  }, [isShiftPressed, manchetteWithSpaceTimeChartRef]);
 
   const handleKeyDown = useCallback((event: KeyboardEvent) => {
     if (event.key === 'Shift') {
@@ -143,10 +358,9 @@ const useManchettesWithSpaceTimeChart = (
     setState((prev) => ({ ...prev, isProportional: !prev.isProportional }));
   }, []);
 
-  const computedScales = useMemo(
-    () => getScales(simplifiedWaypoints, { height, isProportional, yZoom }),
-    [simplifiedWaypoints, height, isProportional, yZoom]
-  );
+  const toggleZoomMode = useCallback(() => {
+    setState((prev) => ({ ...prev, zoomMode: !prev.zoomMode }));
+  }, []);
 
   const manchetteProps = useMemo(
     () => ({
@@ -162,16 +376,6 @@ const useManchettesWithSpaceTimeChart = (
     [waypointsToDisplay, zoomYIn, zoomYOut, resetZoom, toggleMode, yZoom, isProportional, yOffset]
   );
 
-  const handleXZoom = useCallback(
-    (newXZoom: number, xPosition = (spaceTimeChartRef?.current?.offsetWidth || 0) / 2) => {
-      setState((prev) => ({
-        ...prev,
-        ...zoomX(prev.xZoom, prev.xOffset, newXZoom, xPosition),
-      }));
-    },
-    [spaceTimeChartRef]
-  );
-
   const spaceTimeChartProps = useMemo(
     () => ({
       operationalPoints: simplifiedWaypoints,
@@ -180,39 +384,86 @@ const useManchettesWithSpaceTimeChart = (
       paths,
       xOffset,
       yOffset: -yOffset + 14,
+      timeOrigin,
+      spaceOrigin,
+      rect,
       onZoom: ({ delta, position }: Parameters<NonNullable<SpaceTimeChartProps['onZoom']>>[0]) => {
         if (isShiftPressed) {
           handleXZoom(xZoom + delta, position.x);
         }
       },
-      onPan: (payload: {
-        initialPosition: { x: number; y: number };
-        position: { x: number; y: number };
-        isPanning: boolean;
-      }) => {
-        const diff = getDistance(payload.initialPosition, payload.position);
-        const newState = { ...state };
+      onPan: (payload: Parameters<NonNullable<SpaceTimeChartProps['onPan']>>[0]) => {
+        const {
+          initialData,
+          data,
+          initialPosition,
+          position,
+          isPanning,
+          context: { width, getData },
+        } = payload;
+        const diff = getDistance(initialPosition, position);
+        setState((prev) => {
+          if (!isPanning) {
+            return {
+              ...prev,
+              panning: null,
+              zoomMode: false,
+            };
+          }
 
-        if (!payload.isPanning) {
-          newState.panning = null;
-        } else if (!panning) {
-          newState.panning = { initialOffset: { x: xOffset, y: yOffset } };
-        } else {
+          if (state.zoomMode) {
+            const minPoint = getData({ x: 0, y: 0 });
+            const maxPoint = getData({ x: width, y: canvasDrawingHeight });
+            const timeStart = clamp(initialData.time, minPoint.time, maxPoint.time);
+            const timeEnd = clamp(data.time, minPoint.time, maxPoint.time);
+            const spaceStart = clamp(initialData.position, minPoint.position, maxPoint.position);
+            const spaceEnd = clamp(data.position, minPoint.position, maxPoint.position);
+            const newRect: State['rect'] = {
+              timeStart: new Date(timeStart),
+              timeEnd: new Date(timeEnd),
+              spaceStart,
+              spaceEnd,
+            };
+
+            let newPixelRect: State['pixelRect'] = null;
+            if (!isProportional) {
+              const xStart = clamp(initialPosition.x, 0, width);
+              const xEnd = clamp(position.x, 0, width);
+              const yStart = clamp(initialPosition.y, 0, canvasDrawingHeight);
+              const yEnd = clamp(position.y, 0, canvasDrawingHeight);
+              newPixelRect = { xStart, xEnd, yStart, yEnd };
+            }
+
+            return {
+              ...prev,
+              rect: newRect,
+              pixelRect: newPixelRect,
+            };
+          }
+
+          if (!panning) {
+            return {
+              ...prev,
+              panning: { initialOffset: { x: xOffset, y: yOffset } },
+            };
+          }
+
+          const newState = { ...prev };
           const { initialOffset } = panning;
           newState.xOffset = initialOffset.x + diff.x;
 
           const newYPos = initialOffset.y - diff.y;
           if (
-            manchetteWithSpaceTimeChartContainer.current &&
+            manchetteWithSpaceTimeChartRef.current &&
             newYPos >= 0 &&
-            newYPos + manchetteWithSpaceTimeChartContainer.current.offsetHeight <
-              manchetteWithSpaceTimeChartContainer.current.scrollHeight
+            newYPos + manchetteWithSpaceTimeChartRef.current.offsetHeight <
+              manchetteWithSpaceTimeChartRef.current.scrollHeight
           ) {
             newState.yOffset = newYPos;
-            manchetteWithSpaceTimeChartContainer.current.scrollTop = newYPos;
+            manchetteWithSpaceTimeChartRef.current.scrollTop = newYPos;
           }
-        }
-        setState(newState);
+          return newState;
+        });
       },
     }),
     [
@@ -225,11 +476,21 @@ const useManchettesWithSpaceTimeChart = (
       state,
       panning,
       yOffset,
-      manchetteWithSpaceTimeChartContainer,
+      manchetteWithSpaceTimeChartRef,
       handleXZoom,
+      isProportional,
+      rect,
+      spaceOrigin,
+      timeOrigin,
+      canvasDrawingHeight,
     ]
   );
 
+  const timeScale = useMemo(() => zoomValueToTimeScale(xZoom), [xZoom]);
+  const spaceScale = useMemo(
+    () => zoomValueToSpaceScale(minZoomMillimeterPerPx, maxZoomMillimeterPerPx, yZoom),
+    [yZoom, minZoomMillimeterPerPx, maxZoomMillimeterPerPx]
+  );
   return useMemo(
     () => ({
       manchetteProps,
@@ -237,9 +498,27 @@ const useManchettesWithSpaceTimeChart = (
       handleScroll,
       handleXZoom,
       xZoom,
+      toggleZoomMode,
+      zoomMode,
+      rect,
+      timeScale,
+      spaceScale,
+      setTimeOrigin,
     }),
-    [manchetteProps, spaceTimeChartProps, handleScroll, handleXZoom, xZoom]
+    [
+      manchetteProps,
+      spaceTimeChartProps,
+      handleScroll,
+      handleXZoom,
+      xZoom,
+      zoomMode,
+      rect,
+      spaceScale,
+      timeScale,
+      toggleZoomMode,
+      setTimeOrigin,
+    ]
   );
 };
 
-export default useManchettesWithSpaceTimeChart;
+export default useManchetteWithSpaceTimeChart;

--- a/ui-charts/src/manchette/utils/__tests__/helpers.spec.ts
+++ b/ui-charts/src/manchette/utils/__tests__/helpers.spec.ts
@@ -1,70 +1,122 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, test, expect } from 'vitest';
 
-import { BASE_WAYPOINT_HEIGHT } from '../../consts';
-import { computeWaypointsToDisplay, getScales } from '../helpers';
+import { BASE_WAYPOINT_HEIGHT, MAX_ZOOM_Y, MIN_ZOOM_Y } from '../../consts';
+import {
+  computeWaypointsToDisplay,
+  getScales,
+  getExtremaScales,
+  spaceScaleToZoomValue,
+  zoomValueToSpaceScale,
+} from '../helpers';
 
 // Assuming these types from your code
 
 // Mock data for the tests
 const mockedWaypoints = [
   { position: 0, id: 'waypoint-1' },
-  { position: 10, id: 'waypoint-2' },
-  { position: 20, id: 'waypoint-3' },
+  { position: 100_000_000, id: 'waypoint-2' },
+  { position: 200_000_000, id: 'waypoint-3' },
 ];
 
 describe('computeWaypointsToDisplay', () => {
+  const minZoomMillimeterPerPx = 500_000;
+  const maxZoomMillimeterPerPx = 1_000;
   it('should ensure that a empty array is returned when there is only 1 waypoint', () => {
-    const result = computeWaypointsToDisplay([mockedWaypoints[0]], {
-      height: 500,
-      isProportional: true,
-      yZoom: 1,
-    });
+    const result = computeWaypointsToDisplay(
+      [mockedWaypoints[0]],
+      {
+        height: 500,
+        isProportional: true,
+        yZoom: 1,
+      },
+      minZoomMillimeterPerPx,
+      maxZoomMillimeterPerPx
+    );
     expect(result.length).toBe(0);
   });
 
   it('should display all points for non-proportional display', () => {
-    const result = computeWaypointsToDisplay(mockedWaypoints, {
-      height: 100,
-      isProportional: false,
-      yZoom: 1,
-    });
+    const result = computeWaypointsToDisplay(
+      mockedWaypoints,
+      {
+        height: 100,
+        isProportional: false,
+        yZoom: 1,
+      },
+      minZoomMillimeterPerPx,
+      maxZoomMillimeterPerPx
+    );
     expect(result).toHaveLength(mockedWaypoints.length);
     expect(result[0].styles?.height).toBe(`${BASE_WAYPOINT_HEIGHT}px`);
     expect(result[1].styles?.height).toBe(`${BASE_WAYPOINT_HEIGHT}px`);
   });
 
   it('should correctly filter waypoints', () => {
-    const result = computeWaypointsToDisplay(mockedWaypoints, {
-      height: 100,
-      isProportional: true,
-      yZoom: 1,
-    });
+    const result = computeWaypointsToDisplay(
+      mockedWaypoints,
+      {
+        height: 100,
+        isProportional: true,
+        yZoom: 1,
+      },
+      minZoomMillimeterPerPx,
+      maxZoomMillimeterPerPx
+    );
     expect(result).toHaveLength(2);
   });
 
-  it('should return correct heights for proportional display', () => {
-    const result = computeWaypointsToDisplay(mockedWaypoints, {
-      height: 500,
-      isProportional: true,
-      yZoom: 2,
-    });
+  it('should return correct heights for proportional display, zoom 1', () => {
+    const result = computeWaypointsToDisplay(
+      mockedWaypoints,
+      {
+        height: 500,
+        isProportional: true,
+        yZoom: 1,
+      },
+      minZoomMillimeterPerPx,
+      maxZoomMillimeterPerPx
+    );
     expect(result).toHaveLength(mockedWaypoints.length);
-    expect(result[0].styles?.height).toBe(`428px`);
-    expect(result[1].styles?.height).toBe(`428px`);
+    expect(result[0].styles?.height).toBe(`200px`);
+    expect(result[1].styles?.height).toBe(`200px`);
+    expect(result[2].styles?.height).toBe(`${BASE_WAYPOINT_HEIGHT}px`);
+  });
+
+  it('should return correct heights for proportional display, zoom 2', () => {
+    const result = computeWaypointsToDisplay(
+      mockedWaypoints,
+      {
+        height: 500,
+        isProportional: true,
+        yZoom: 2,
+      },
+      minZoomMillimeterPerPx,
+      maxZoomMillimeterPerPx
+    );
+    expect(result).toHaveLength(mockedWaypoints.length);
+    expect(result[0].styles?.height).toBe(`385px`);
+    expect(result[1].styles?.height).toBe(`385px`);
     expect(result[2].styles?.height).toBe(`${BASE_WAYPOINT_HEIGHT}px`);
   });
 
   it('should ensure the last point is always displayed', () => {
-    const result = computeWaypointsToDisplay(mockedWaypoints, {
-      height: 100,
-      isProportional: true,
-      yZoom: 1,
-    });
+    const result = computeWaypointsToDisplay(
+      mockedWaypoints,
+      {
+        height: 100,
+        isProportional: true,
+        yZoom: 1,
+      },
+      minZoomMillimeterPerPx,
+      maxZoomMillimeterPerPx
+    );
     expect(result.some((waypoint) => waypoint.id === 'waypoint-3')).toBe(true);
   });
 });
 
 describe('getScales', () => {
+  const minZoomMillimeterPerPx = 500_000;
+  const maxZoomMillimeterPerPx = 1_000;
   const mockOpsWithPosition = mockedWaypoints.map((waypoint) => ({
     id: waypoint.id,
     label: waypoint.id,
@@ -74,34 +126,82 @@ describe('getScales', () => {
 
   it('Should ensure that a empty array is return when there is only 1 waypoint', () => {
     const ops = [mockOpsWithPosition[0]];
-    const result = getScales(ops, {
-      height: 500,
-      isProportional: true,
-      yZoom: 1,
-    });
+    const result = getScales(
+      ops,
+      {
+        height: 500,
+        isProportional: true,
+        yZoom: 1,
+      },
+      minZoomMillimeterPerPx,
+      maxZoomMillimeterPerPx
+    );
     expect(result).toHaveLength(0);
   });
 
   it('should return correct scale coefficients for proportional display', () => {
-    const result = getScales(mockOpsWithPosition, {
-      height: 500,
-      isProportional: true,
-      yZoom: 1,
-    });
-    expect(result).toHaveLength(1);
-    expect(result[0]).toHaveProperty('coefficient');
+    const result = getScales(
+      mockOpsWithPosition,
+      {
+        height: 500,
+        isProportional: true,
+        yZoom: 1,
+      },
+      minZoomMillimeterPerPx,
+      maxZoomMillimeterPerPx
+    );
+    expect(result).toEqual([{ from: 0, to: 200000000, coefficient: 500000 }]);
     expect(result[0].size).not.toBeDefined();
   });
 
   it('should return correct size for non-proportional display', () => {
-    const result = getScales(mockOpsWithPosition, {
-      height: 500,
-      isProportional: false,
-      yZoom: 1,
-    });
+    const result = getScales(
+      mockOpsWithPosition,
+      {
+        height: 500,
+        isProportional: false,
+        yZoom: 1,
+      },
+      minZoomMillimeterPerPx,
+      maxZoomMillimeterPerPx
+    );
 
-    expect(result).toHaveLength(2);
-    expect(result[0].size).toBeDefined();
+    expect(result).toEqual([
+      { from: 0, to: 100000000, size: 32 },
+      { from: 100000000, to: 200000000, size: 32 },
+    ]);
     expect(result[0]).not.toHaveProperty('coefficient');
+  });
+});
+
+describe('space scale functions', () => {
+  const pathLength = 168056000; // mm
+  const drawingHeightWithoutTopPadding = 505;
+  const drawingHeightWithoutBothPadding = 489;
+
+  const { minZoomMillimeterPerPx, maxZoomMillimeterPerPx } = getExtremaScales(
+    drawingHeightWithoutTopPadding,
+    drawingHeightWithoutBothPadding,
+    pathLength
+  );
+  expect(minZoomMillimeterPerPx).toBeCloseTo(343672.801);
+  expect(maxZoomMillimeterPerPx).toBeCloseTo(990.1);
+
+  test('zoomValueToSpaceScale', () => {
+    expect(
+      zoomValueToSpaceScale(minZoomMillimeterPerPx, maxZoomMillimeterPerPx, MIN_ZOOM_Y)
+    ).toBeCloseTo(343672.801);
+    expect(
+      zoomValueToSpaceScale(minZoomMillimeterPerPx, maxZoomMillimeterPerPx, MAX_ZOOM_Y)
+    ).toBeCloseTo(990.1);
+  });
+
+  test('spaceScaleToZoomValue', () => {
+    expect(
+      spaceScaleToZoomValue(minZoomMillimeterPerPx, maxZoomMillimeterPerPx, 343672.801)
+    ).toBeCloseTo(MIN_ZOOM_Y);
+    expect(
+      spaceScaleToZoomValue(minZoomMillimeterPerPx, maxZoomMillimeterPerPx, 990.1)
+    ).toBeCloseTo(MAX_ZOOM_Y);
   });
 });

--- a/ui-charts/src/manchette/utils/helpers.ts
+++ b/ui-charts/src/manchette/utils/helpers.ts
@@ -7,10 +7,74 @@ import {
   MAX_ZOOM_X,
   MIN_ZOOM_MS_PER_PX,
   MIN_ZOOM_X,
+  MAX_ZOOM_Y,
+  MIN_ZOOM_Y,
+  MAX_ZOOM_MANCHETTE_HEIGHT_MILLIMETER,
 } from '../consts';
 import type { InteractiveWaypoint, Waypoint } from '../types';
 
-type WaypointsOptions = { isProportional: boolean; yZoom: number; height: number };
+export const zoomValueToTimeScale = (slider: number) =>
+  MIN_ZOOM_MS_PER_PX * Math.pow(MAX_ZOOM_MS_PER_PX / MIN_ZOOM_MS_PER_PX, slider / 100);
+
+export const timeScaleToZoomValue = (timeScale: number) =>
+  (100 * Math.log(timeScale / MIN_ZOOM_MS_PER_PX)) /
+  Math.log(MAX_ZOOM_MS_PER_PX / MIN_ZOOM_MS_PER_PX);
+
+/**
+ * min zoom is computed with manchette px height between first and last waypoint.
+ * max zoom just the canvas drawing height (without the x-axis scale section)
+ */
+export const getExtremaScales = (
+  drawingHeightWithoutTopPadding: number,
+  drawingHeightWithoutBothPadding: number,
+  pathLengthMillimeter: number
+) => ({
+  minZoomMillimeterPerPx: pathLengthMillimeter / drawingHeightWithoutBothPadding,
+  maxZoomMillimeterPerPx: MAX_ZOOM_MANCHETTE_HEIGHT_MILLIMETER / drawingHeightWithoutTopPadding,
+});
+
+export const zoomValueToSpaceScale = (
+  minZoomMillimeterPerPx: number,
+  maxZoomMillimeterPerPx: number,
+  slider: number
+) =>
+  minZoomMillimeterPerPx *
+  Math.pow(
+    maxZoomMillimeterPerPx / minZoomMillimeterPerPx,
+    (slider - MIN_ZOOM_Y) / (MAX_ZOOM_Y - MIN_ZOOM_Y)
+  );
+
+export const spaceScaleToZoomValue = (
+  minZoomMillimeterPerPx: number,
+  maxZoomMillimeterPerPx: number,
+  spaceScale: number
+) =>
+  ((MAX_ZOOM_Y - MIN_ZOOM_Y) * Math.log(spaceScale / minZoomMillimeterPerPx)) /
+    Math.log(maxZoomMillimeterPerPx / minZoomMillimeterPerPx) +
+  MIN_ZOOM_Y;
+
+/** Zoom on X axis and center on the mouse position */
+export const zoomX = (
+  currentZoom: number,
+  currentOffset: number,
+  newZoom: number,
+  position: number
+) => {
+  const boundedZoom = clamp(newZoom, MIN_ZOOM_X, MAX_ZOOM_X);
+  const oldTimeScale = zoomValueToTimeScale(currentZoom);
+  const newTimeScale = zoomValueToTimeScale(boundedZoom);
+  const newOffset = position - ((position - currentOffset) * oldTimeScale) / newTimeScale;
+  return {
+    xZoom: boundedZoom,
+    xOffset: newOffset,
+  };
+};
+
+type WaypointsOptions = {
+  isProportional: boolean;
+  yZoom: number;
+  height: number;
+};
 
 export const filterVisibleElements = (
   elements: Waypoint[],
@@ -43,20 +107,23 @@ export const filterVisibleElements = (
 
 export const computeWaypointsToDisplay = (
   waypoints: Waypoint[],
-  { height, isProportional, yZoom }: WaypointsOptions
+  { height, isProportional, yZoom }: WaypointsOptions,
+  minZoomMillimeterPerPx: number,
+  maxZoomMillimeterPerPx: number
 ): InteractiveWaypoint[] => {
   if (waypoints.length < 2) return [];
 
   const totalDistance = calcTotalDistance(waypoints);
-  const heightWithoutFinalWaypoint = getHeightWithoutLastWaypoint(height);
+  const manchetteHeight = getHeightWithoutLastWaypoint(height);
 
   // display all waypoints in linear mode
   if (!isProportional) {
     return waypoints.map((waypoint, index) => {
       const nextWaypoint = waypoints.at(index + 1);
+      const waypointHeight = BASE_WAYPOINT_HEIGHT * (nextWaypoint ? yZoom : 1);
       return {
         ...waypoint,
-        styles: { height: `${BASE_WAYPOINT_HEIGHT * (nextWaypoint ? yZoom : 1)}px` },
+        styles: { height: `${waypointHeight}px` },
       };
     });
   }
@@ -67,30 +134,36 @@ export const computeWaypointsToDisplay = (
   const filteredWaypoints = filterVisibleElements(
     waypoints,
     totalDistance,
-    heightWithoutFinalWaypoint,
+    manchetteHeight,
     minSpace
   );
 
+  const spaceScale = zoomValueToSpaceScale(minZoomMillimeterPerPx, maxZoomMillimeterPerPx, yZoom);
+
   return filteredWaypoints.map((waypoint, index) => {
     const nextWaypoint = filteredWaypoints.at(index + 1);
+    const waypointHeight = !nextWaypoint
+      ? BASE_WAYPOINT_HEIGHT
+      : (nextWaypoint.position - waypoint.position) / spaceScale;
     return {
       ...waypoint,
       styles: {
-        height: !nextWaypoint
-          ? `${BASE_WAYPOINT_HEIGHT}px`
-          : `${
-              ((nextWaypoint.position - waypoint.position) / totalDistance) *
-              heightWithoutFinalWaypoint *
-              yZoom
-            }px`,
+        height: `${Math.round(waypointHeight)}px`,
       },
     };
   });
 };
 
+/**
+ * 2 modes for space scales
+ * km (isProportional): { coefficient: gives a scale in meter/pixel }
+ * linear: { size: height in pixel  } (each point distributed evenly along the height of manchette.)
+ */
 export const getScales = (
   waypoints: Waypoint[],
-  { height, isProportional, yZoom }: WaypointsOptions
+  { isProportional, yZoom }: WaypointsOptions,
+  minZoomMillimeterPerPx: number,
+  maxZoomMillimeterPerPx: number
 ) => {
   if (waypoints.length < 2) return [];
 
@@ -109,11 +182,8 @@ export const getScales = (
   const from = waypoints.at(0)!.position;
   const to = waypoints.at(-1)!.position;
 
-  const totalDistance = calcTotalDistance(waypoints);
-  const heightWithoutFinalWaypoint = getHeightWithoutLastWaypoint(height);
-
   const scaleCoeff = isProportional
-    ? { coefficient: totalDistance / heightWithoutFinalWaypoint / yZoom }
+    ? { coefficient: zoomValueToSpaceScale(minZoomMillimeterPerPx, maxZoomMillimeterPerPx, yZoom) }
     : { size: BASE_WAYPOINT_HEIGHT * (waypoints.length - 1) * yZoom };
 
   return [
@@ -123,28 +193,4 @@ export const getScales = (
       ...scaleCoeff,
     },
   ];
-};
-
-export const zoomValueToTimeScale = (slider: number) =>
-  MIN_ZOOM_MS_PER_PX * Math.pow(MAX_ZOOM_MS_PER_PX / MIN_ZOOM_MS_PER_PX, slider / 100);
-
-export const timeScaleToZoomValue = (timeScale: number) =>
-  (100 * Math.log(timeScale / MIN_ZOOM_MS_PER_PX)) /
-  Math.log(MAX_ZOOM_MS_PER_PX / MIN_ZOOM_MS_PER_PX);
-
-/** Zoom on X axis and center on the mouse position */
-export const zoomX = (
-  currentZoom: number,
-  currentOffset: number,
-  newZoom: number,
-  position: number
-) => {
-  const boundedZoom = clamp(newZoom, MIN_ZOOM_X, MAX_ZOOM_X);
-  const oldTimeScale = zoomValueToTimeScale(currentZoom);
-  const newTimeScale = zoomValueToTimeScale(boundedZoom);
-  const newOffset = position - ((position - currentOffset) * oldTimeScale) / newTimeScale;
-  return {
-    xZoom: boundedZoom,
-    xOffset: newOffset,
-  };
 };

--- a/ui-charts/src/spaceTimeChart/index.ts
+++ b/ui-charts/src/spaceTimeChart/index.ts
@@ -20,3 +20,6 @@ export * from './components/OccupancyBlockLayer';
 export * from './components/WorkScheduleLayer';
 export * from './components/PatternRect';
 export * from './components/Quadrilateral';
+export * from './components/ZoomRect';
+export * from './components/TimeCaptions';
+export * from './stories/lib/components';

--- a/ui-charts/src/spaceTimeChart/stories/rectangle-zoom.stories.tsx
+++ b/ui-charts/src/spaceTimeChart/stories/rectangle-zoom.stories.tsx
@@ -24,9 +24,9 @@ const MAX_ZOOM = 100;
 const MIN_ZOOM_MS_PER_PX = 600000;
 const MAX_ZOOM_MS_PER_PX = 625;
 const DEFAULT_ZOOM_MS_PER_PX = 10000;
-const MIN_ZOOM_METRE_PER_PX = 10000;
-const MAX_ZOOM_METRE_PER_PX = 10;
-const DEFAULT_ZOOM_METRE_PER_PX = 300;
+const MIN_ZOOM_METER_PER_PX = 10000;
+const MAX_ZOOM_METER_PER_PX = 10;
+const DEFAULT_ZOOM_METER_PER_PX = 300;
 type SpaceTimeHorizontalZoomWrapperProps = {
   swapAxes: boolean;
   spaceOrigin: number;
@@ -44,11 +44,11 @@ const timeScaleToZoomValue = (timeScale: number) =>
   Math.log(MAX_ZOOM_MS_PER_PX / MIN_ZOOM_MS_PER_PX);
 
 const zoomValueToSpaceScale = (slider: number) =>
-  MIN_ZOOM_METRE_PER_PX * Math.pow(MAX_ZOOM_METRE_PER_PX / MIN_ZOOM_METRE_PER_PX, slider / 100);
+  MIN_ZOOM_METER_PER_PX * Math.pow(MAX_ZOOM_METER_PER_PX / MIN_ZOOM_METER_PER_PX, slider / 100);
 
 const spaceScaleToZoomValue = (spaceScale: number) =>
-  (100 * Math.log(spaceScale / MIN_ZOOM_METRE_PER_PX)) /
-  Math.log(MAX_ZOOM_METRE_PER_PX / MIN_ZOOM_METRE_PER_PX);
+  (100 * Math.log(spaceScale / MIN_ZOOM_METER_PER_PX)) /
+  Math.log(MAX_ZOOM_METER_PER_PX / MIN_ZOOM_METER_PER_PX);
 
 type StoryState = {
   timeZoomValue: number;
@@ -78,7 +78,7 @@ const RectangleZoomWrapper = ({
 }: SpaceTimeHorizontalZoomWrapperProps) => {
   const [state, setState] = useState<StoryState>({
     timeZoomValue: timeScaleToZoomValue(DEFAULT_ZOOM_MS_PER_PX),
-    spaceZoomValue: spaceScaleToZoomValue(DEFAULT_ZOOM_METRE_PER_PX),
+    spaceZoomValue: spaceScaleToZoomValue(DEFAULT_ZOOM_METER_PER_PX),
     xOffset,
     yOffset,
     panning: null,
@@ -92,7 +92,7 @@ const RectangleZoomWrapper = ({
     {
       from: -100000,
       to: 100000,
-      coefficient: zoomValueToSpaceScale(state.spaceZoomValue), // metre/px
+      coefficient: zoomValueToSpaceScale(state.spaceZoomValue), // meter/px
     },
   ];
 
@@ -117,7 +117,7 @@ const RectangleZoomWrapper = ({
         }
 
         const newTimeScale = clamp(chosenTimeScale, MAX_ZOOM_MS_PER_PX, MIN_ZOOM_MS_PER_PX);
-        const newSpaceScale = clamp(chosenSpaceScale, MAX_ZOOM_METRE_PER_PX, MIN_ZOOM_METRE_PER_PX);
+        const newSpaceScale = clamp(chosenSpaceScale, MAX_ZOOM_METER_PER_PX, MIN_ZOOM_METER_PER_PX);
         const timeZoomValue = timeScaleToZoomValue(newTimeScale);
         const spaceZoomValue = spaceScaleToZoomValue(newSpaceScale);
 
@@ -203,7 +203,7 @@ const RectangleZoomWrapper = ({
     if (state.rect && !state.zoomMode) {
       const { timeStart, timeEnd, spaceStart, spaceEnd } = state.rect;
       const timeRange = Math.abs(Number(timeEnd) - Number(timeStart)); // width of rect in ms
-      const spaceRange = Math.abs(spaceEnd - spaceStart); // height of rect in metre
+      const spaceRange = Math.abs(spaceEnd - spaceStart); // height of rect in meter
       const chosenTimeScale = !swapAxes ? timeRange / DEFAULT_WIDTH : timeRange / DEFAULT_HEIGHT;
       const chosenSpaceScale = !swapAxes
         ? spaceRange / (DEFAULT_HEIGHT - CAPTION_SIZE)
@@ -221,14 +221,14 @@ const RectangleZoomWrapper = ({
         ...prev,
         ...(!swapAxes
           ? { timeZoomValue: timeScaleToZoomValue(DEFAULT_ZOOM_MS_PER_PX) }
-          : { spaceZoomValue: spaceScaleToZoomValue(DEFAULT_ZOOM_METRE_PER_PX) }),
+          : { spaceZoomValue: spaceScaleToZoomValue(DEFAULT_ZOOM_METER_PER_PX) }),
         xOffset: 0,
       }));
     } else {
       setState((prev) => ({
         ...prev,
         ...(!swapAxes
-          ? { spaceZoomValue: spaceScaleToZoomValue(DEFAULT_ZOOM_METRE_PER_PX) }
+          ? { spaceZoomValue: spaceScaleToZoomValue(DEFAULT_ZOOM_METER_PER_PX) }
           : { timeZoomValue: timeScaleToZoomValue(DEFAULT_ZOOM_MS_PER_PX) }),
         yOffset: 0,
       }));


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/10960

### y scale requirements
- **min zoom => the entire path is shown** 
  the scale min zoom metre/px value depends on the length of the path (which is not the case with the time axis, which are constants)
- **max zoom => the entire height of the manchette is 500 meter.**

### map yZoom -> mm/px scale
Previously, `yZoom` was used as a multiplier. `yScale` was just changed by increments of `0.5`  (using the + or - buttons) and the  height in pixel was just multiplied by `yScale`. This approach is not enough as we need to be able to navigate arbitrary zoom levels and to know how much the size of a rectangle means in term of yZoom.
To do that we need functions to map back and forth between the `yZoom` level and the value of the scale in mm/px. 
this is what `zoomValueToSpaceScale` `spaceScaleToZoomValue` do.

seeing that with the min zoom level we need to display the entire path, min Zoom scale value also depends on the length of the path. min and max scale values are given by `getExtremaScales`

#### `getExtremaScales` example:

![Screenshot_20250312_120237-1](https://github.com/user-attachments/assets/8519e36d-042d-4cee-94f4-df87e00b6f38)

Min zoom level is given by the **entire path length** being represented between some top and bottom padding (here we have 489 px between them), which gives: `168 km/489 px = 343672 mm/px`

for max zoom level, we keep only the top padding (to keep the beginning of the path in place, while the arrival exits the view), which gives `500 m/505 px = 990 mm/px`

| zoom level | mm/px |
| ----- | ----- |
| 1 | 343672 |
| 10,5 | 990 |

https://www.desmos.com/calculator/ayz6dhx24a

#### non proportional mode
in non proportional mode (linear, every stop has the same height on the manchette), we’re not using a mm/px scale. We directly convert rectangle px height (extended to the full chart height) means in term of stop height. 
