### PR TITLE
Remove dist/ JS imports 

### DIFF
--- a/ui-manchette-with-spacetimechart/src/assets/sampleData.ts
+++ b/ui-manchette-with-spacetimechart/src/assets/sampleData.ts
@@ -1,5 +1,4 @@
-/* eslint-disable import/no-unresolved */
-import { type ProjectPathTrainResult, type Waypoint } from '@osrd-project/ui-manchette/dist/types';
+import { type ProjectPathTrainResult, type Waypoint } from '@osrd-project/ui-manchette';
 
 export const SAMPLE_WAYPOINTS: Waypoint[] = [
   {

--- a/ui-manchette-with-spacetimechart/src/hooks/useManchetteWithSpaceTimeChart.ts
+++ b/ui-manchette-with-spacetimechart/src/hooks/useManchetteWithSpaceTimeChart.ts
@@ -1,10 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import type { ProjectPathTrainResult, Waypoint } from '@osrd-project/ui-manchette/dist/types';
-import type {
-  SpaceScale,
-  SpaceTimeChartProps,
-} from '@osrd-project/ui-spacetimechart/dist/lib/types';
+import type { ProjectPathTrainResult, Waypoint } from '@osrd-project/ui-manchette';
+import type { SpaceScale, SpaceTimeChartProps } from '@osrd-project/ui-spacetimechart';
 
 import usePaths from './usePaths';
 import { MAX_ZOOM_Y, MIN_ZOOM_Y, ZOOM_Y_DELTA, DEFAULT_ZOOM_MS_PER_PX } from '../consts';

--- a/ui-manchette-with-spacetimechart/src/hooks/usePaths.ts
+++ b/ui-manchette-with-spacetimechart/src/hooks/usePaths.ts
@@ -1,7 +1,6 @@
-/* eslint-disable import/no-unresolved */
 import { useMemo } from 'react';
 
-import { type ProjectPathTrainResult } from '@osrd-project/ui-manchette/dist/types';
+import { type ProjectPathTrainResult } from '@osrd-project/ui-manchette';
 import { type PathLevel } from '@osrd-project/ui-spacetimechart';
 
 import { PATH_COLOR_DEFAULT } from '../consts';

--- a/ui-spacetimechart/src/index.ts
+++ b/ui-spacetimechart/src/index.ts
@@ -1,6 +1,15 @@
 import './styles/main.css';
 
-export type { HoveredItem, SpaceTimeChartProps } from './lib/types';
+export type {
+  HoveredItem,
+  SpaceTimeChartProps,
+  SpaceScale,
+  OperationalPoint,
+  SpaceTimeChartTheme,
+  Point,
+  DataPoint,
+  SpaceTimeChartContextType,
+} from './lib/types';
 
 export * from './components/SpaceTimeChart';
 export * from './components/PathLayer';


### PR DESCRIPTION
Instead, import from the package itself. That way we can ensure
we're only importing public API and we're not messing with
internal types.

Drop the eslint-disable import/no-unresolved comments, because
these errors aren't triggered anymore.

_See individual commits._