### PR TITLE
ui-manchette-with-spacetimechart: add ManchetteWithSpaceTimeChart

### DIFF
--- a/ui-manchette-with-spacetimechart/src/components/ManchetteWithSpaceTimeChart.tsx
+++ b/ui-manchette-with-spacetimechart/src/components/ManchetteWithSpaceTimeChart.tsx
@@ -1,0 +1,93 @@
+import React, { useRef } from 'react';
+
+import Manchette, {
+  type ProjectPathTrainResult,
+  type Waypoint,
+  type ManchetteProps,
+} from '@osrd-project/ui-manchette';
+import {
+  PathLayer,
+  SpaceTimeChart,
+  type SpaceTimeChartProps,
+} from '@osrd-project/ui-spacetimechart';
+
+import useManchetteWithSpaceTimeChart from '../hooks/useManchetteWithSpaceTimeChart';
+
+export type ManchetteWithSpaceTimeChartProps = {
+  waypoints: Waypoint[];
+  projectPathTrainResult: ProjectPathTrainResult[];
+  selectedTrain?: number;
+  height?: number;
+  children?: React.ReactNode;
+  header?: React.ReactNode;
+  manchetteProps?: ManchetteProps;
+  spaceTimeChartProps?: SpaceTimeChartProps;
+};
+
+/**
+ * A simple component to display a manchette and a space time chart.
+ *
+ * This only covers basic usage. For more advanced control over the manchette
+ * and space time chart, the useManchetteWithSpaceTimeChart() hook can be used.
+ */
+const ManchetteWithSpaceTimeChart = ({
+  waypoints,
+  projectPathTrainResult,
+  selectedTrain,
+  height = 561,
+  children,
+  header,
+  manchetteProps: additionalManchetteProps,
+  spaceTimeChartProps: additionalSpaceTimeChartProps,
+}: ManchetteWithSpaceTimeChartProps) => {
+  const manchetteWithSpaceTimeChartRef = useRef<HTMLDivElement>(null);
+  const spaceTimeChartRef = useRef<HTMLDivElement>(null);
+
+  const { manchetteProps, spaceTimeChartProps, handleScroll } = useManchetteWithSpaceTimeChart(
+    waypoints,
+    projectPathTrainResult,
+    manchetteWithSpaceTimeChartRef,
+    selectedTrain,
+    height,
+    spaceTimeChartRef
+  );
+
+  return (
+    <div className="manchette-space-time-chart-wrapper">
+      <div
+        className="header bg-ambientB-5 w-full border-b border-grey-30"
+        style={{ height: '40px' }}
+      >
+        {header}
+      </div>
+      <div
+        ref={manchetteWithSpaceTimeChartRef}
+        className="manchette flex"
+        style={{ height: `${height}px` }}
+        onScroll={handleScroll}
+      >
+        <Manchette {...manchetteProps} {...additionalManchetteProps} />
+        <div
+          className="space-time-chart-container w-full sticky"
+          ref={spaceTimeChartRef}
+          style={{ bottom: 0, left: 0, top: 2, height: `${height - 6}px` }}
+        >
+          <SpaceTimeChart
+            className="inset-0 absolute h-full"
+            spaceOrigin={0}
+            timeOrigin={Math.min(...projectPathTrainResult.map((p) => +p.departureTime))}
+            {...spaceTimeChartProps}
+            {...additionalSpaceTimeChartProps}
+          >
+            {spaceTimeChartProps.paths.map((path) => (
+              <PathLayer key={path.id} path={path} color={path.color} level={path.level} />
+            ))}
+            {children}
+          </SpaceTimeChart>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ManchetteWithSpaceTimeChart;

--- a/ui-manchette-with-spacetimechart/src/index.ts
+++ b/ui-manchette-with-spacetimechart/src/index.ts
@@ -1,5 +1,6 @@
 import './styles/main.css';
 
-export { default as useManchettesWithSpaceTimeChart } from './hooks/useManchetteWithSpaceTimeChart';
+export { default as useManchetteWithSpaceTimeChart } from './hooks/useManchetteWithSpaceTimeChart';
+export { default as ManchetteWithSpaceTimeChart } from './components/ManchetteWithSpaceTimeChart';
 export { DEFAULT_ZOOM_MS_PER_PX } from './consts';
 export { timeScaleToZoomValue } from './helpers';

--- a/ui-manchette-with-spacetimechart/src/stories/simple.stories.tsx
+++ b/ui-manchette-with-spacetimechart/src/stories/simple.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta } from '@storybook/react';
+
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-manchette/dist/theme.css';
+import '@osrd-project/ui-manchette-with-spacetimechart/dist/theme.css';
+
+import { SAMPLE_WAYPOINTS, SAMPLE_PATHS_DATA } from '../assets/sampleData';
+import ManchetteWithSpaceTimeChart from '../components/ManchetteWithSpaceTimeChart';
+
+const meta: Meta<typeof ManchetteWithSpaceTimeChart> = {
+  title: 'Manchette with SpaceTimeChart/simple',
+  component: ManchetteWithSpaceTimeChart,
+};
+
+export default meta;
+
+export const Default = {
+  args: {
+    waypoints: SAMPLE_WAYPOINTS,
+    projectPathTrainResult: SAMPLE_PATHS_DATA,
+    selectedTrain: 1,
+  },
+};

--- a/ui-manchette/src/components/Manchette.tsx
+++ b/ui-manchette/src/components/Manchette.tsx
@@ -7,7 +7,7 @@ import { INITIAL_OP_LIST_HEIGHT, MAX_ZOOM_Y, MIN_ZOOM_Y } from './consts';
 import WaypointList from './WaypointList';
 import type { InteractiveWaypoint, WaypointMenuData } from '../types';
 
-type ManchetteProps = {
+export type ManchetteProps = {
   waypoints: InteractiveWaypoint[];
   waypointMenuData?: WaypointMenuData;
   zoomYIn: () => void;

--- a/ui-manchette/src/index.ts
+++ b/ui-manchette/src/index.ts
@@ -2,7 +2,5 @@ import '@osrd-project/ui-core/dist/theme.css';
 import './styles/main.css';
 import './components/consts';
 
-import Manchette from './components/Manchette';
-
-export default Manchette;
+export { default, type ManchetteProps } from './components/Manchette';
 export type { WaypointMenuData, Waypoint, ProjectPathTrainResult } from './types';


### PR DESCRIPTION
This is a component designed for simple use-cases. It's easier to
use than the hook. Users can still decide to use the hook instead
of this component, especially when they need more customizability.

Other components can be passed in for the header and SpaceTimeChart,
and additional properties can be passed to Manchette/SpaceTimeChart.

This is a breaking API change: the hook is no longer the default
export for ui-manchette-with-spacetimechart. Users need to replace:

    import useManchetteWithSpaceTimeChart from 'ui-manchette-with-spacetimechart';

with:

    import { useManchetteWithSpaceTimeChart } from 'ui-manchette-with-spacetimechart';

_See individual commits._