### PR TITLE
ui-spacetimechart: fix op graduation display when hidden

### DIFF
--- a/ui-spacetimechart/src/components/SpaceTimeChart.tsx
+++ b/ui-spacetimechart/src/components/SpaceTimeChart.tsx
@@ -63,6 +63,7 @@ export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
   const fingerprint = useMemo(
     () =>
       JSON.stringify({
+        operationalPoints,
         width,
         height,
         spaceOrigin,
@@ -77,6 +78,7 @@ export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
         showTicks,
       }),
     [
+      operationalPoints,
       width,
       height,
       spaceOrigin,


### PR DESCRIPTION
add operationnalPoints in fingerprint to trigger changes in useCanvas() then redraw charts if one or many operationnalPoints is hidden by machette settings panel

to test it, go to work-schedules `spacetimechart`story, remove one or several OPs

close https://github.com/OpenRailAssociation/osrd/issues/9970