### PR TITLE
storybook: fix include paths in TypeScript configuration

### DIFF
--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.base.json",
-  "include": [".storybook/*.tsx", "stories/**/*"],
+  "include": [".storybook/**/*", "stories/**/*"],
   "compilerOptions": {
     "rootDir": "../",
     "outDir": "./dist",


### PR DESCRIPTION
".storybook/*.tsx" didn't match any file: files in this directory have the .ts extension.

Let's just drop the file extension and include all files in this directory.

Tested with `npx tsc --noEmit --listFiles | grep osrd-ui/storybook`.