### PR TITLE
ui-spacetimechart: upgrades time captions

### DIFF
--- a/storybook/stories/ui-charts/spaceTimeChart/additional-data.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/additional-data.stories.tsx
@@ -25,6 +25,7 @@ import {
 } from './helpers/utils';
 
 import '@osrd-project/ui-charts/dist/theme.css';
+import '@osrd-project/ui-core/dist/theme.css';
 
 const MONO_TRACK_SPACES = [
   { from: 6 * KILOMETER, to: 24 * KILOMETER },

--- a/storybook/stories/ui-charts/spaceTimeChart/base-rendering.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/base-rendering.stories.tsx
@@ -7,6 +7,7 @@ import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL } from './helpers/utils';
 
 import '@osrd-project/ui-charts/dist/theme.css';
+import '@osrd-project/ui-core/dist/theme.css';
 
 type WrapperProps = {
   xZoomLevel: number;

--- a/storybook/stories/ui-charts/spaceTimeChart/custom-styles.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/custom-styles.stories.tsx
@@ -16,6 +16,7 @@ import {
 } from './helpers/utils';
 
 import '@osrd-project/ui-charts/dist/theme.css';
+import '@osrd-project/ui-core/dist/theme.css';
 
 const DEFAULT_COLOR_1 = '#FF511A';
 const DEFAULT_COLOR_2 = '#FF8B61';

--- a/storybook/stories/ui-charts/spaceTimeChart/layers.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/layers.stories.tsx
@@ -22,6 +22,7 @@ import {
 import { OPERATIONAL_POINTS, PATHS, START_DATE } from './helpers/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL } from './helpers/utils';
 
+import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
 
 const CONFLICTS = [

--- a/storybook/stories/ui-charts/spaceTimeChart/measuring.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/measuring.stories.tsx
@@ -8,6 +8,7 @@ import { MouseTracker } from './helpers/components';
 import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom, getDiff } from './helpers/utils';
 
+import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
 
 type WrapperProps = {

--- a/storybook/stories/ui-charts/spaceTimeChart/options.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/options.stories.tsx
@@ -46,6 +46,7 @@ type WrapperProps = {
   enableSnapping: boolean;
   hideGrid: boolean;
   hidePathsLabels: boolean;
+  hideDates: boolean;
   swapAxis: boolean;
   spaceScaleType: 'linear' | 'proportional';
 };
@@ -59,6 +60,7 @@ const Wrapper = ({
   enableSnapping,
   hideGrid,
   hidePathsLabels,
+  hideDates,
   swapAxis,
   spaceScaleType,
 }: WrapperProps) => {
@@ -83,6 +85,7 @@ const Wrapper = ({
         enableSnapping={enableSnapping}
         hideGrid={hideGrid}
         hidePathsLabels={hidePathsLabels}
+        hideDates={hideDates}
         swapAxis={swapAxis}
         operationalPoints={OPERATIONAL_POINTS}
         spaceOrigin={0}
@@ -177,6 +180,11 @@ export default {
       defaultValue: false,
       control: { type: 'boolean' },
     },
+    hideDates: {
+      name: 'Hide dates?',
+      defaultValue: false,
+      control: { type: 'boolean' },
+    },
     swapAxis: {
       name: 'Swap time and space axis?',
       defaultValue: false,
@@ -197,6 +205,7 @@ export const DefaultArgs = {
     enableSnapping: true,
     hideGrid: false,
     hidePathsLabels: false,
+    hideDates: false,
     swapAxis: false,
     spaceScaleType: 'linear',
   },

--- a/storybook/stories/ui-charts/spaceTimeChart/options.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/options.stories.tsx
@@ -17,6 +17,9 @@ import {
   getDiff,
 } from './helpers/utils';
 
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
+
 const ScreenshotButton = () => {
   const { captureCanvases } = useContext(CanvasContext);
 

--- a/storybook/stories/ui-charts/spaceTimeChart/paths-interactions.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/paths-interactions.stories.tsx
@@ -15,6 +15,7 @@ import { keyBy } from 'lodash';
 import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom, getDiff } from './helpers/utils';
 
+import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
 
 function delayPath<T extends PathData>(path: T, newTimeOrigin: number): T {

--- a/storybook/stories/ui-charts/spaceTimeChart/performances.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/performances.stories.tsx
@@ -14,6 +14,7 @@ import { KILOMETER, MINUTE } from './helpers/consts';
 import { getPaths, type PATHS } from './helpers/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom, getDiff } from './helpers/utils';
 
+import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
 
 const DATE_OFFSET = +new Date('2024/01/01');

--- a/storybook/stories/ui-charts/spaceTimeChart/quadrilateral.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/quadrilateral.stories.tsx
@@ -12,6 +12,7 @@ import { HOUR } from './helpers/consts';
 import { OPERATIONAL_POINTS, PATHS, START_DATE } from './helpers/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL } from './helpers/utils';
 
+import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
 
 type WrapperProps = {

--- a/storybook/stories/ui-charts/spaceTimeChart/rectangle-zoom.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/rectangle-zoom.stories.tsx
@@ -4,10 +4,10 @@ import {
   PathLayer,
   SpaceTimeChart,
   ZoomRect,
-  CAPTION_SIZE,
   type Point,
   type PathData,
   type OperationalPoint,
+  DEFAULT_THEME,
 } from '@osrd-project/ui-charts';
 import { Button, Slider } from '@osrd-project/ui-core';
 import type { Meta } from '@storybook/react';
@@ -210,9 +210,10 @@ const RectangleZoomWrapper = ({
       const timeRange = Math.abs(Number(timeEnd) - Number(timeStart)); // width of rect in ms
       const spaceRange = Math.abs(spaceEnd - spaceStart); // height of rect in meter
       const chosenTimeScale = !swapAxes ? timeRange / DEFAULT_WIDTH : timeRange / DEFAULT_HEIGHT;
+      const captionSize = DEFAULT_THEME.dateCaptionsSize + DEFAULT_THEME.timeCaptionsSize;
       const chosenSpaceScale = !swapAxes
-        ? spaceRange / (DEFAULT_HEIGHT - CAPTION_SIZE)
-        : spaceRange / (DEFAULT_WIDTH - CAPTION_SIZE);
+        ? spaceRange / (DEFAULT_HEIGHT - captionSize)
+        : spaceRange / (DEFAULT_WIDTH - captionSize);
       handleRectangleZoom({
         scales: { chosenTimeScale, chosenSpaceScale },
         overrideState: { rect: null },

--- a/storybook/stories/ui-charts/spaceTimeChart/scroll-navigation.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/scroll-navigation.stories.tsx
@@ -16,6 +16,7 @@ import { keyBy } from 'lodash';
 import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL, zoom, getDiff } from './helpers/utils';
 
+import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
 
 const PATHS_DICT = keyBy(PATHS, 'id');

--- a/storybook/stories/ui-charts/spaceTimeChart/split.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/split.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 
 import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
 
 import {
   PathLayer,

--- a/storybook/stories/ui-charts/spaceTimeChart/stage-interactions.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/stage-interactions.stories.tsx
@@ -15,6 +15,9 @@ import {
   getDiff,
 } from './helpers/utils';
 
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
+
 type WrapperProps = {
   xPan: boolean;
   yPan: boolean;

--- a/storybook/stories/ui-charts/spaceTimeChart/tooltip.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/tooltip.stories.tsx
@@ -12,6 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
 import { X_ZOOM_LEVEL, Y_ZOOM_LEVEL } from './helpers/utils';
 
+import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
 
 const CustomTooltipContent = ({

--- a/storybook/stories/ui-charts/spaceTimeChart/work-schedules.stories.tsx
+++ b/storybook/stories/ui-charts/spaceTimeChart/work-schedules.stories.tsx
@@ -9,12 +9,14 @@ import {
   type OperationalPoint,
   type WorkSchedule,
 } from '@osrd-project/ui-charts';
-import '@osrd-project/ui-core/dist/theme.css';
 import type { Meta } from '@storybook/react';
 
 import upward from './assets/images/ScheduledMaintenanceUp.svg';
 import { OPERATIONAL_POINTS, PATHS } from './helpers/paths';
 import { getDiff } from './helpers/utils';
+
+import '@osrd-project/ui-core/dist/theme.css';
+import '@osrd-project/ui-charts/dist/theme.css';
 
 const SAMPLE_WORK_SCHEDULES: WorkSchedule[] = [
   {

--- a/storybook/stories/ui-charts/trackOccupancyDiagram/rendering.stories.tsx
+++ b/storybook/stories/ui-charts/trackOccupancyDiagram/rendering.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import occupancyZones from './assets/occupancyZones';
 import tracks from './assets/tracks';
-import TimeCaptions from '../../../../ui-charts/src/spaceTimeChart/components/TimeCaptions';
+import { TimeCaptions } from '../../../../ui-charts/src/spaceTimeChart/components/TimeCaptions';
 import { useCanvas, useDraw } from '../../../../ui-charts/src/spaceTimeChart/hooks/useCanvas';
 import { useMouseInteractions } from '../../../../ui-charts/src/spaceTimeChart/hooks/useMouseInteractions';
 import { useMouseTracking } from '../../../../ui-charts/src/spaceTimeChart/hooks/useMouseTracking';

--- a/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
+++ b/ui-charts/src/spaceTimeChart/components/PathLayer.tsx
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 
 import { inRange, last } from 'lodash';
 
-import { CAPTION_SIZE } from './TimeCaptions';
 import { useDraw, usePicking } from '../hooks/useCanvas';
 import {
   type DataPoint,
@@ -225,6 +224,7 @@ export const PathLayer = ({
         width,
         height,
         swapAxis,
+        captionSize,
         theme: {
           background,
           pathsStyles: { fontSize, fontFamily },
@@ -239,8 +239,8 @@ export const PathLayer = ({
 
       const firstPointOnScreenIndex = points.findIndex(({ x, y }) =>
         !swapAxis
-          ? inRange(x, 0, width) && inRange(y, 0, height - CAPTION_SIZE)
-          : inRange(x, CAPTION_SIZE, width) && inRange(y, 0, height)
+          ? inRange(x, 0, width) && inRange(y, 0, height - captionSize)
+          : inRange(x, captionSize, width) && inRange(y, 0, height)
       );
 
       if (firstPointOnScreenIndex < 0) return;
@@ -255,12 +255,13 @@ export const PathLayer = ({
       if (firstPointOnScreenIndex === 0) {
         if (next) angle = Math.atan2(next.y - curr.y, next.x - curr.x);
       } else {
+        const minX = swapAxis ? captionSize : 0;
         const slope = (curr.y - prev.y) / (curr.x - prev.x);
-        const yOnYAxisIntersect = curr.y - curr.x * slope;
-        const xOnXAxisIntersect = curr.x - curr.y / slope;
+        const yOnYAxisIntersect = curr.y - (curr.x - minX) * slope;
+        const xOnXAxisIntersect = curr.x - minX - curr.y / slope;
         if (yOnYAxisIntersect >= 0) {
           position = {
-            x: 0,
+            x: minX,
             y: yOnYAxisIntersect,
           };
         } else {

--- a/ui-charts/src/spaceTimeChart/components/SpaceTimeChart.tsx
+++ b/ui-charts/src/spaceTimeChart/components/SpaceTimeChart.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import cx from 'classnames';
 
 import SpaceGraduations from './SpaceGraduations';
-import TimeCaptions from './TimeCaptions';
+import { TimeCaptions } from './TimeCaptions';
 import TimeGraduations from './TimeGraduations';
 import { useCanvas } from '../hooks/useCanvas';
 import { useMouseInteractions } from '../hooks/useMouseInteractions';
@@ -45,6 +45,7 @@ export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
     hideGrid,
     hidePathsLabels,
     showTicks,
+    hideDates,
     theme,
     /* eslint-disable @typescript-eslint/no-unused-vars */
     onPan,
@@ -76,6 +77,7 @@ export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
         hideGrid,
         hidePathsLabels,
         showTicks,
+        hideDates,
       }),
     [
       operationalPoints,
@@ -91,6 +93,7 @@ export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
       hideGrid,
       hidePathsLabels,
       showTicks,
+      hideDates,
     ]
   );
 
@@ -154,7 +157,11 @@ export const SpaceTimeChart = (props: SpaceTimeChartProps) => {
       hideGrid: !!hideGrid,
       hidePathsLabels: !!hidePathsLabels,
       showTicks: !!showTicks,
+      hideDates: !!hideDates,
       theme: fullTheme,
+      captionSize: hideDates
+        ? fullTheme.timeCaptionsSize
+        : fullTheme.dateCaptionsSize + fullTheme.timeCaptionsSize,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fingerprint]);

--- a/ui-charts/src/spaceTimeChart/components/TimeCaptions.tsx
+++ b/ui-charts/src/spaceTimeChart/components/TimeCaptions.tsx
@@ -1,10 +1,11 @@
 import { useCallback } from 'react';
 
 import { useDraw } from '../hooks/useCanvas';
-import { MINUTE } from '../lib/consts';
+import { HOUR, MINUTE } from '../lib/consts';
 import { type DrawingFunction } from '../lib/types';
 import { computeVisibleTimeMarkers, getCrispLineCoordinate } from '../utils/canvas';
 
+const MARGIN = 100;
 const MINUTES_FORMATTER = (t: number) => `:${new Date(t).getMinutes().toString().padStart(2, '0')}`;
 const HOURS_FORMATTER = (t: number, pixelsPerMinute: number) => {
   const date = new Date(t);
@@ -16,8 +17,15 @@ const HOURS_FORMATTER = (t: number, pixelsPerMinute: number) => {
     return date.getHours().toString().padStart(2, '0');
   }
 };
+const DATES_FORMATER = (t: number) => {
+  const date = new Date(t);
+  return [
+    date.getDate().toString().padStart(2, '0'),
+    (date.getMonth() + 1).toString().padStart(2, '0'),
+    date.getFullYear().toString(),
+  ].join('/');
+};
 
-export const CAPTION_SIZE = 33;
 const RANGES_FORMATER: ((t: number, pixelsPerMinute: number) => string)[] = [
   () => '',
   () => '',
@@ -32,7 +40,7 @@ const RANGES_FORMATER: ((t: number, pixelsPerMinute: number) => string)[] = [
   HOURS_FORMATTER,
 ];
 
-const TimeCaptions = () => {
+export const TimeCaptions = () => {
   const drawingFunction = useCallback<DrawingFunction>(
     (
       ctx,
@@ -51,14 +59,19 @@ const TimeCaptions = () => {
           timeCaptionsPriorities,
           timeCaptionsStyles,
           timeGraduationsStyles,
+          dateCaptionsStyle,
         },
+        captionSize,
+        hideDates,
         showTicks,
       }
     ) => {
       const timeAxisSize = !swapAxis ? width : height;
-      const spaceAxisSize = !swapAxis ? height : width;
-      const minT = timeOrigin - timeScale * timePixelOffset;
-      const maxT = minT + timeScale * width;
+      const spaceAxisSize = (!swapAxis ? height : width) - captionSize;
+
+      // Add some margin, so that captions of times right outside the stage are still visible:
+      const minT = timeOrigin - timeScale * (timePixelOffset + MARGIN);
+      const maxT = minT + timeScale * (width + MARGIN * 2);
 
       // Find which styles to apply, relatively to the timescale (i.e. horizontal zoom level):
       const pixelsPerMinute = (1 / timeScale) * MINUTE;
@@ -72,25 +85,65 @@ const TimeCaptions = () => {
         return false;
       });
 
-      const labelMarkFormatter = (labelLevel: number, i: number) => ({
-        level: labelLevel,
-        rangeIndex: i,
-      });
-      const labelMarks = computeVisibleTimeMarkers(
+      let labelMarks = computeVisibleTimeMarkers(
         minT,
         maxT,
         timeRanges,
         labelLevels,
-        labelMarkFormatter
+        (level: number, i: number) => ({
+          level,
+          styles: timeCaptionsStyles[level],
+          formatter: RANGES_FORMATER[i],
+        })
       );
-
+      if (!hideDates)
+        labelMarks = labelMarks.concat(
+          computeVisibleTimeMarkers(minT, maxT, [24 * HOUR], [1], (level: number) => ({
+            level,
+            styles: dateCaptionsStyle,
+            formatter: DATES_FORMATER,
+          }))
+        );
       // Render caption background:
       ctx.fillStyle = background;
       if (!swapAxis) {
-        ctx.fillRect(0, spaceAxisSize - CAPTION_SIZE, timeAxisSize, CAPTION_SIZE);
+        ctx.fillRect(0, spaceAxisSize, timeAxisSize, captionSize);
       } else {
-        ctx.fillRect(0, 0, CAPTION_SIZE, timeAxisSize);
+        ctx.fillRect(0, 0, captionSize, timeAxisSize);
       }
+
+      // Render time captions:
+      labelMarks.forEach(({ styles, formatter, time }) => {
+        const text = formatter(time, pixelsPerMinute);
+
+        ctx.textAlign = styles.textAlign || 'center';
+        ctx.textBaseline = 'top';
+        ctx.fillStyle = styles.color;
+        ctx.lineWidth = 5;
+        ctx.strokeStyle = background;
+        ctx.lineCap = 'butt';
+        ctx.font = `${styles.fontWeight || 'normal'} ${styles.font}`;
+        const timePixel = getCrispLineCoordinate(getTimePixel(time), ctx.lineWidth);
+
+        if (!swapAxis) {
+          if (showTicks) {
+            ctx.strokeStyle = timeCaptionsStyles[1].color;
+            ctx.moveTo(timePixel, spaceAxisSize);
+            ctx.lineTo(timePixel, time % 180000 === 0 ? 8 : 4);
+            ctx.stroke();
+          }
+
+          ctx.strokeText(text, timePixel, spaceAxisSize + (styles.topOffset || 0));
+          ctx.fillText(text, timePixel, spaceAxisSize + (styles.topOffset || 0));
+        } else {
+          ctx.save();
+          ctx.translate(captionSize - (styles.topOffset || 0), timePixel);
+          ctx.rotate(Math.PI / 2);
+          ctx.strokeText(text, 0, 0);
+          ctx.fillText(text, 0, 0);
+          ctx.restore();
+        }
+      });
 
       // Render caption top border:
       ctx.strokeStyle = timeGraduationsStyles[1].color;
@@ -98,45 +151,15 @@ const TimeCaptions = () => {
       if (!showTicks) {
         ctx.beginPath();
         if (!swapAxis) {
-          const y = getCrispLineCoordinate(spaceAxisSize - CAPTION_SIZE, ctx.lineWidth);
+          const y = getCrispLineCoordinate(spaceAxisSize, ctx.lineWidth);
           ctx.moveTo(0, y);
           ctx.lineTo(timeAxisSize, y);
         } else {
-          const x = getCrispLineCoordinate(CAPTION_SIZE, ctx.lineWidth);
+          const x = getCrispLineCoordinate(captionSize, ctx.lineWidth);
           ctx.moveTo(x, 0);
           ctx.lineTo(x, timeAxisSize);
         }
         ctx.stroke();
-      }
-
-      // Render time captions:
-      for (const t in labelMarks) {
-        const { level, rangeIndex } = labelMarks[t];
-        const styles = timeCaptionsStyles[level];
-        const formatter = RANGES_FORMATER[rangeIndex];
-        const text = formatter(+t, pixelsPerMinute);
-
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'top';
-        ctx.fillStyle = styles.color;
-        ctx.font = `${styles.fontWeight || 'normal'} ${styles.font}`;
-        const timePixel = getCrispLineCoordinate(getTimePixel(+t), ctx.lineWidth);
-
-        if (!swapAxis) {
-          if (showTicks) {
-            ctx.strokeStyle = timeCaptionsStyles[1].color;
-            ctx.moveTo(timePixel, spaceAxisSize - CAPTION_SIZE);
-            ctx.lineTo(timePixel, +t % 180000 === 0 ? 8 : 4);
-            ctx.stroke();
-          }
-          ctx.fillText(text, timePixel, spaceAxisSize - CAPTION_SIZE + (styles.topOffset || 0));
-        } else {
-          ctx.save();
-          ctx.translate(CAPTION_SIZE - (styles.topOffset || 0), timePixel);
-          ctx.rotate(Math.PI / 2);
-          ctx.fillText(text, 0, 0);
-          ctx.restore();
-        }
       }
     },
     []
@@ -146,5 +169,3 @@ const TimeCaptions = () => {
 
   return null;
 };
-
-export default TimeCaptions;

--- a/ui-charts/src/spaceTimeChart/components/TimeGraduations.tsx
+++ b/ui-charts/src/spaceTimeChart/components/TimeGraduations.tsx
@@ -38,12 +38,11 @@ const TimeGraduations = () => {
         return false;
       });
 
-      const gridMarks = computeVisibleTimeMarkers<number>(minT, maxT, timeRanges, gridlinesLevels);
+      const gridMarks = computeVisibleTimeMarkers(minT, maxT, timeRanges, gridlinesLevels);
 
       // Render grid lines:
-      for (const t in gridMarks) {
-        const gridlinesLevel = gridMarks[t];
-        const styles = timeGraduationsStyles[gridlinesLevel];
+      gridMarks.forEach(({ time, level }) => {
+        const styles = timeGraduationsStyles[level];
 
         ctx.strokeStyle = styles.color;
         ctx.lineWidth = styles.width;
@@ -53,7 +52,7 @@ const TimeGraduations = () => {
           ctx.lineDashOffset = -spacePixelOffset;
         }
 
-        const timePixel = getCrispLineCoordinate(getTimePixel(+t), ctx.lineWidth);
+        const timePixel = getCrispLineCoordinate(getTimePixel(time), ctx.lineWidth);
         ctx.beginPath();
         if (!swapAxis) {
           ctx.moveTo(timePixel, 0);
@@ -63,7 +62,7 @@ const TimeGraduations = () => {
           ctx.lineTo(spaceAxisSize, timePixel);
         }
         ctx.stroke();
-      }
+      });
 
       ctx.setLineDash([]);
       ctx.lineDashOffset = 0;

--- a/ui-charts/src/spaceTimeChart/lib/consts.ts
+++ b/ui-charts/src/spaceTimeChart/lib/consts.ts
@@ -1,24 +1,33 @@
 import { type SpaceTimeChartTheme } from './types';
 
-// Colors:
-const BLACK = '#000000';
-const BLUE = '#2170B9';
-const GREY_10 = '#EDEDED';
-const GREY_30 = '#B6B2AF';
-const GREY_50 = '#797671';
+export const BLACK = '#000000';
+export const BLUE = '#2170B9';
+export const GREY_10 = '#EDEDED';
+export const GREY_30 = '#B6B3AF';
+export const GREY_50 = '#797671';
+export const WHITE = '#FFFFFF';
+export const WHITE_75 = '#FFFFFFC0';
+export const AMBIANT_A10 = '#EFF3F5';
+export const ERROR_30 = '#FF6868';
+export const ERROR_60 = '#D91C1C';
+
+// Occupancy blocks colors :
+export const OCCUPANCY_FREE = '#CAEDDB';
+export const OCCUPANCY_SEMAPHORE = '#FFD4D8';
+export const OCCUPANCY_WARNING = '#FFEABF';
 
 // Fonts:
-const FONT_SIZE = 10;
-const FONT = 'IBM Plex Sans';
+export const FONT_SIZE = 10;
+export const FONT = 'IBM Plex Sans, sans-serif';
 
 // Here are some helpers to write code about time in ms that is humanly readable:
-const SECOND = 1000;
+export const SECOND = 1000;
 export const MINUTE = 60 * SECOND;
-const HOUR = 60 * MINUTE;
+export const HOUR = 60 * MINUTE;
 
 export const DEFAULT_THEME: SpaceTimeChartTheme = {
   background: 'white',
-  breakpoints: [0.2, 0.4, 0.8, 2.4, 12, 32, 72, Infinity],
+  breakpoints: [0.2, 0.5, 1, 4, 16, 48, 72, Infinity],
   timeRanges: [
     10 * SECOND,
     30 * SECOND,
@@ -56,84 +65,89 @@ export const DEFAULT_THEME: SpaceTimeChartTheme = {
   // and with which priority level:
   // - Each line corresponds to a breakpoint, in the same order as in the BREAKPOINTS array
   // - Each column corresponds to a time range, in the same order as in the TIME_RANGES array
+  timeCaptionsSize: 40,
   timeCaptionsPriorities: [
     [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
     [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
-    [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
+    [0, 0, 0, 0, 0, 0, 2, 1, 1, 1, 1],
     [0, 0, 0, 0, 0, 3, 1, 1, 1, 1, 1],
     [0, 0, 0, 0, 3, 1, 1, 1, 1, 1, 1],
     [0, 0, 0, 3, 2, 1, 1, 1, 1, 1, 1],
     [0, 0, 3, 2, 1, 1, 1, 1, 1, 1, 1],
-    [0, 0, 3, 2, 1, 1, 1, 1, 1, 1, 1],
+    [0, 0, 3, 1, 1, 1, 1, 1, 1, 1, 1],
   ],
   timeCaptionsStyles: {
     1: {
       color: GREY_50,
       font: `12px ${FONT}`,
-      topOffset: 11,
+      topOffset: 12,
     },
     2: {
       color: GREY_30,
       font: `12px ${FONT}`,
-      topOffset: 9,
+      topOffset: 12,
     },
     3: {
       color: GREY_30,
       font: `10px ${FONT}`,
       topOffset: 6,
     },
-    4: {
-      color: GREY_30,
-      font: `8px ${FONT}`,
-      topOffset: 8,
-    },
+  },
+  dateCaptionsSize: 0,
+  dateCaptionsStyle: {
+    color: GREY_30,
+    font: `10px ${FONT}`,
+    topOffset: 28,
+    textAlign: 'left',
   },
   // The following matrix indicate, for various zoom levels, what time marks should be represented,
   // and with which priority level:
   // - Each line corresponds to a breakpoint, in the same order as in the BREAKPOINTS array
   // - Each column corresponds to a time range, in the same order as in the TIME_RANGES array
   timeGraduationsPriorities: [
-    [0, 0, 0, 0, 0, 0, 0, 4, 3, 2, 1],
-    [0, 0, 0, 0, 0, 0, 4, 3, 3, 2, 1],
+    [0, 0, 0, 0, 0, 0, 0, 6, 4, 2, 1],
+    [0, 0, 0, 0, 0, 0, 6, 5, 5, 2, 1],
     [0, 0, 0, 0, 0, 6, 4, 3, 3, 2, 1],
-    [0, 0, 0, 0, 6, 5, 4, 3, 3, 2, 1],
+    [0, 0, 0, 0, 6, 5, 4, 3, 2, 2, 1],
     [0, 0, 0, 6, 5, 4, 3, 2, 2, 2, 1],
     [0, 0, 6, 5, 4, 4, 3, 2, 2, 2, 1],
-    [0, 6, 5, 4, 4, 4, 3, 2, 2, 2, 1],
-    [6, 0, 5, 4, 4, 4, 3, 2, 2, 2, 1],
+    [0, 6, 5, 4, 3, 3, 2, 2, 2, 2, 1],
+    [6, 5, 4, 3, 3, 3, 2, 2, 2, 2, 1],
   ],
   timeGraduationsStyles: {
     1: {
-      width: 0.5,
+      width: 0.75,
       color: BLACK,
+      opacity: 0.5,
     },
     2: {
       width: 0.5,
       color: BLUE,
-      opacity: 0.77,
+      opacity: 0.7,
     },
     3: {
       width: 0.5,
       color: BLUE,
-      opacity: 0.5,
+      opacity: 0.7,
+      dashArray: [80, 8],
     },
     4: {
       width: 0.5,
       color: BLUE,
-      opacity: 0.5,
-      dashArray: [6, 6],
+      opacity: 0.6,
+      dashArray: [16, 4],
     },
     5: {
       width: 0.5,
       color: BLUE,
-      opacity: 0.5,
-      dashArray: [6, 18],
+      opacity: 0.6,
+      dashArray: [8, 8],
     },
     6: {
-      width: 1,
+      width: 0.75,
       color: BLUE,
-      opacity: 0.5,
-      dashArray: [1, 12],
+      opacity: 0.6,
+      dashArray: [2, 8],
     },
   },
 };

--- a/ui-charts/src/spaceTimeChart/lib/types.ts
+++ b/ui-charts/src/spaceTimeChart/lib/types.ts
@@ -139,12 +139,26 @@ export type MouseContextType = MouseState & {
   hoveredItem: HoveredItem | null;
 };
 
-export type LineStyle = { width: number; color: string; opacity?: number; dashArray?: number[] };
+export type LineStyle = {
+  width: number;
+  color: string;
+  opacity?: number;
+  dashArray?: number[];
+};
+
+export type CaptionStyle = {
+  color: string;
+  font: string;
+  fontWeight?: string;
+  fontSize?: string;
+  topOffset?: number;
+  textAlign?: CanvasTextAlign;
+};
 
 // STYLES:
 export type SpaceTimeChartTheme = {
   background: string;
-  breakpoints: number[];
+  breakpoints: number[]; // in pixels/minute
   timeRanges: number[];
   pathsStyles: {
     fontSize: number;
@@ -152,18 +166,12 @@ export type SpaceTimeChartTheme = {
   };
   spaceGraduationsStyles: Record<number, LineStyle>;
   timeCaptionsPriorities: number[][];
-  timeCaptionsStyles: Record<
-    number,
-    {
-      color: string;
-      font: string;
-      fontWeight?: string;
-      fontSize?: string;
-      topOffset?: number;
-    }
-  >;
+  timeCaptionsStyles: Record<number, CaptionStyle>;
+  timeCaptionsSize: number;
   timeGraduationsPriorities: number[][];
   timeGraduationsStyles: Record<number, LineStyle>;
+  dateCaptionsStyle: CaptionStyle;
+  dateCaptionsSize: number;
 };
 
 // CORE COMPONENT MAIN TYPES:
@@ -195,6 +203,7 @@ export type SpaceTimeChartProps = {
   // Additional options to show/hide context information:
   hideGrid?: boolean;
   hidePathsLabels?: boolean;
+  hideDates?: boolean;
   showTicks?: boolean;
 
   // Custom styles:
@@ -274,10 +283,12 @@ export type SpaceTimeChartContextType = {
 
   // Full theme:
   theme: SpaceTimeChartTheme;
+  captionSize: number;
 
   // Other options:
   enableSnapping: boolean;
   hideGrid: boolean;
   hidePathsLabels: boolean;
+  hideDates: boolean;
   showTicks: boolean;
 };

--- a/ui-charts/src/spaceTimeChart/utils/__tests__/canvas.spec.ts
+++ b/ui-charts/src/spaceTimeChart/utils/__tests__/canvas.spec.ts
@@ -16,29 +16,29 @@ describe('displayElementsBasedOnZoom', () => {
     ];
     const gridlinesLevels = [0, 0, 0, 0, 6, 5, 4, 3, 3, 2, 1];
     const result = computeVisibleTimeMarkers(minT, maxT, timeRanges, gridlinesLevels);
-    expect(result).toEqual({
-      '1712008800000': 1,
-      '1712009700000': 6,
-      '1712010600000': 5,
-      '1712011500000': 6,
-      '1712012400000': 4,
-      '1712013300000': 6,
-      '1712014200000': 5,
-      '1712015100000': 6,
-      '1712016000000': 4,
-      '1712016900000': 6,
-      '1712017800000': 5,
-      '1712018700000': 6,
-      '1712019600000': 3,
-      '1712020500000': 6,
-      '1712021400000': 5,
-      '1712022300000': 6,
-      '1712023200000': 4,
-      '1712024100000': 6,
-      '1712025000000': 5,
-    });
-    const times = Object.keys(result).map((t) =>
-      new Date(Number(t)).toLocaleTimeString('fr-FR', { timeZone: 'Europe/Paris' })
+    expect(result).toEqual([
+      { level: 1, time: 1712008800000 },
+      { level: 6, time: 1712009700000 },
+      { level: 5, time: 1712010600000 },
+      { level: 6, time: 1712011500000 },
+      { level: 4, time: 1712012400000 },
+      { level: 6, time: 1712013300000 },
+      { level: 5, time: 1712014200000 },
+      { level: 6, time: 1712015100000 },
+      { level: 4, time: 1712016000000 },
+      { level: 6, time: 1712016900000 },
+      { level: 5, time: 1712017800000 },
+      { level: 6, time: 1712018700000 },
+      { level: 3, time: 1712019600000 },
+      { level: 6, time: 1712020500000 },
+      { level: 5, time: 1712021400000 },
+      { level: 6, time: 1712022300000 },
+      { level: 4, time: 1712023200000 },
+      { level: 6, time: 1712024100000 },
+      { level: 5, time: 1712025000000 },
+    ]);
+    const times = result.map(({ time }) =>
+      new Date(time).toLocaleTimeString('fr-FR', { timeZone: 'Europe/Paris' })
     );
 
     expect(times).toEqual([
@@ -72,23 +72,23 @@ describe('displayElementsBasedOnZoom', () => {
     ];
     const gridlinesLevels = [0, 0, 0, 0, 0, 0, 4, 3, 3, 2, 1];
     const result = computeVisibleTimeMarkers(minT, maxT, timeRanges, gridlinesLevels);
-    expect(result).toEqual({
-      '1712023200000': 1,
-      '1712026800000': 4,
-      '1712030400000': 4,
-      '1712034000000': 3,
-      '1712037600000': 4,
-      '1712041200000': 4,
-      '1712044800000': 3,
-      '1712048400000': 4,
-      '1712052000000': 4,
-      '1712055600000': 3,
-      '1712059200000': 4,
-      '1712062800000': 4,
-      '1712066400000': 2,
-    });
-    const times = Object.keys(result).map((t) =>
-      new Date(Number(t)).toLocaleTimeString('fr-FR', { timeZone: 'America/Noronha' })
+    expect(result).toEqual([
+      { level: 1, time: 1712023200000 },
+      { level: 4, time: 1712026800000 },
+      { level: 4, time: 1712030400000 },
+      { level: 3, time: 1712034000000 },
+      { level: 4, time: 1712037600000 },
+      { level: 4, time: 1712041200000 },
+      { level: 3, time: 1712044800000 },
+      { level: 4, time: 1712048400000 },
+      { level: 4, time: 1712052000000 },
+      { level: 3, time: 1712055600000 },
+      { level: 4, time: 1712059200000 },
+      { level: 4, time: 1712062800000 },
+      { level: 2, time: 1712066400000 },
+    ]);
+    const times = result.map(({ time }) =>
+      new Date(time).toLocaleTimeString('fr-FR', { timeZone: 'America/Noronha' })
     );
     expect(times).toEqual([
       '00:00:00',

--- a/ui-charts/src/spaceTimeChart/utils/canvas.ts
+++ b/ui-charts/src/spaceTimeChart/utils/canvas.ts
@@ -1,4 +1,4 @@
-import { clamp, identity } from 'lodash';
+import { clamp } from 'lodash';
 
 import type {
   SpaceTimeChartContextType,
@@ -323,24 +323,22 @@ export function drawPathExtremity(
 }
 
 /**
- *
  * @param minT number timestamp
  * @param maxT number timestamp
  * @param timeRanges time frames (24h, 12h, 6h, …)
  * @param gridlinesLevels width of the lines for each time frame
  * @param formatter function to format de values inside the output object
- * @returns Record<number, number>
  * Keys are times in ms
  * Values are the highest level on each time
  */
-export function computeVisibleTimeMarkers<T>(
+export function computeVisibleTimeMarkers<T extends object = { level: number }>(
   minT: number,
   maxT: number,
   timeRanges: number[],
   gridlinesLevels: number[],
-  formatter: (level: number, i: number) => T = identity
-) {
-  const result: Record<number, T> = {};
+  formatter: (level: number, i: number) => T = (level: number) => ({ level }) as T
+): (T & { time: number })[] {
+  const result: Record<number, T & { time: number }> = {};
   const minTLocalOffset = new Date(minT).getTimezoneOffset() * 60 * 1000;
 
   timeRanges.forEach((range, i) => {
@@ -351,12 +349,12 @@ export function computeVisibleTimeMarkers<T>(
     let t = Math.floor((minT - minTLocalOffset) / range) * range + minTLocalOffset;
     while (t <= maxT) {
       if (t >= minT) {
-        result[t] = formatter(gridlinesLevel, i);
+        result[t] = { ...formatter(gridlinesLevel, i), time: t };
       }
       t += range;
     }
   });
-  return result;
+  return Object.values(result);
 }
 
 /**


### PR DESCRIPTION
This commit implements new designs from @thibautsailly, and addresses issue OpenRailAssociation/osrd#10663.

Details:
- Updates styles matrices for time captions and graduations
- Adds date labels
- Adds new option `hideDates` to hide date labels, adds it to the options story
- Adds some margin around the time captions stage, so that captions of times right outside the stage are still visible while panning
- Fixes path labels when axis are swapped