### PR TITLE
build: disallow importing osrd-ui internals

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -124,6 +124,9 @@
     "react/static-property-placement": 0,
     // disable vitest/prefer-to-be because it does not authorize toEqual for the floats
     "vitest/prefer-to-be": "off",
+    "no-restricted-imports": ["error", {
+      "patterns": ["@osrd-project/*/src/*", "*/ui-*/src/*"],
+    }],
   },
   "settings": {
     "react": {


### PR DESCRIPTION
Disallow importing a file straight from another package's src/ directory. This breaks package isolation.