### PR TITLE
front: disable tailwind preflight from ui-core and ui-chart

### DIFF
--- a/storybook/tailwind.config.js
+++ b/storybook/tailwind.config.js
@@ -3,4 +3,7 @@ import osrdUiPreset from '../tailwind-preset.js';
 export default {
   presets: [osrdUiPreset],
   content: ['./stories/**/*.{js,jsx,ts,tsx}'],
+  corePlugins: {
+    preflight: false,
+  },
 };

--- a/ui-charts/src/manchette/styles/main.css
+++ b/ui-charts/src/manchette/styles/main.css
@@ -1,4 +1,3 @@
-@import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 @import 'manchette.css';

--- a/ui-charts/src/spaceTimeChart/styles/main.css
+++ b/ui-charts/src/spaceTimeChart/styles/main.css
@@ -1,4 +1,3 @@
-@import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 

--- a/ui-charts/src/speedSpaceChart/styles/main.css
+++ b/ui-charts/src/speedSpaceChart/styles/main.css
@@ -1,4 +1,3 @@
-@import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 

--- a/ui-charts/src/trackOccupancyDiagram/styles/main.css
+++ b/ui-charts/src/trackOccupancyDiagram/styles/main.css
@@ -1,4 +1,3 @@
-@import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 

--- a/ui-charts/tailwind.config.js
+++ b/ui-charts/tailwind.config.js
@@ -3,4 +3,7 @@ import osrdUiPreset from '../tailwind-preset.js';
 export default {
   presets: [osrdUiPreset],
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  corePlugins: {
+    preflight: false,
+  },
 };

--- a/ui-core/src/styles/main.css
+++ b/ui-core/src/styles/main.css
@@ -1,4 +1,3 @@
-@import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 @import './animations.css';

--- a/ui-core/tailwind.config.js
+++ b/ui-core/tailwind.config.js
@@ -3,4 +3,7 @@ import osrdUiPreset from '../tailwind-preset.js';
 export default {
   presets: [osrdUiPreset],
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  corePlugins: {
+    preflight: false,
+  },
 };


### PR DESCRIPTION
Disable tailwind preflight to prevent css from spilling over.

A lot of preflight apply css to everything (*), which may break application using osrd-ui.

`@import tailwindcss/base` should also be removed as it contain preflight and is redondant (as tailwindcss/components and tailwindcss/utilities are already imported).

Closes: https://github.com/OpenRailAssociation/osrd-ui/issues/988