### PR TITLE
build: drop terser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
       "devDependencies": {
         "@rollup/plugin-eslint": "^9.0.5",
         "@rollup/plugin-node-resolve": "^16.0.0",
-        "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^12.1.0",
         "@types/lodash": "^4.17.13",
         "@types/react": "^18.2.40",
@@ -2377,6 +2376,8 @@
       "version": "0.3.6",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -3528,27 +3529,6 @@
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rollup/plugin-terser": {
-      "version": "0.4.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "serialize-javascript": "^6.0.1",
-        "smob": "^1.0.0",
-        "terser": "^5.17.4"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@rollup/plugin-typescript": {
       "version": "12.1.2",
@@ -15758,14 +15738,6 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rbush": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
@@ -16686,14 +16658,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -16895,11 +16859,6 @@
         "npm": ">= 3.0.0"
       }
     },
-    "node_modules/smob": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/socks": {
       "version": "2.8.3",
       "dev": true,
@@ -16988,6 +16947,8 @@
       "version": "0.5.21",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -17736,6 +17697,8 @@
       "version": "5.31.5",
       "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -17752,7 +17715,9 @@
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/text-extensions": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@rollup/plugin-eslint": "^9.0.5",
     "@rollup/plugin-node-resolve": "^16.0.0",
-    "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.0",
     "@types/lodash": "^4.17.13",
     "@types/react": "^18.2.40",

--- a/rollup-base.config.js
+++ b/rollup-base.config.js
@@ -3,7 +3,6 @@ import path from 'path';
 
 import eslint from '@rollup/plugin-eslint';
 import nodeResolve from '@rollup/plugin-node-resolve';
-import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import livereload from 'rollup-plugin-livereload';
 import postcss from 'rollup-plugin-postcss';
@@ -30,7 +29,6 @@ const generateRollupBaseConfig = () => ({
       sourceMap: true,
       plugins: [],
     }),
-    terser(),
     process.env.ROLLUP_WATCH &&
       livereload({
         watch: 'dist',

--- a/ui-icons/rollup.config.js
+++ b/ui-icons/rollup.config.js
@@ -1,5 +1,4 @@
 import typescript from '@rollup/plugin-typescript';
-import terser from '@rollup/plugin-terser';
 import eslint from '@rollup/plugin-eslint';
 
 const formats = ['esm'];
@@ -13,6 +12,6 @@ export default {
     name: 'osrdicons',
     sourcemap: true,
   })),
-  plugins: [eslint(), typescript(), terser()],
+  plugins: [eslint(), typescript()],
   external: ['react'],
 };


### PR DESCRIPTION
terser minifies the final JavaScript file. This isn't super useful because users have their own build system and minifier, and makes debugging more difficult because other build systems are in general unable to read source maps as input (thus stack traces are obfuscated).