### PR TITLE
ui-charts: fix manchette min height in linear mode

### DIFF
--- a/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
+++ b/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
@@ -434,7 +434,10 @@ const useManchetteWithSpaceTimeChart = ({
   const { manchetteContents, manchetteHeight } = useMemo(() => {
     const spaceScaleTree = spaceScalesToBinaryTree(spaceOrigin, spaceScales);
     const getSpacePixel = getSpaceToPixel(0, spaceScaleTree);
-    const totalManchetteHeight = getSpacePixel(spaceScales.at(-1)!.to, true) + BASE_WAYPOINT_HEIGHT;
+    const totalManchetteHeight = Math.max(
+      getSpacePixel(spaceScales.at(-1)!.to, true) + BASE_WAYPOINT_HEIGHT,
+      height - FOOTER_HEIGHT
+    );
 
     if (!splitPoints)
       return {
@@ -510,7 +513,7 @@ const useManchetteWithSpaceTimeChart = ({
       manchetteHeight: totalManchetteHeight,
       manchetteContents: finalContents,
     };
-  }, [spaceOrigin, spaceScales, splitPoints, waypointsWithoutSplitPoints]);
+  }, [spaceOrigin, spaceScales, splitPoints, waypointsWithoutSplitPoints, height]);
 
   return useMemo<{
     manchetteProps: ManchetteProps;


### PR DESCRIPTION
totalManchetteHeight could be smaller than the chart. Ensure that doesn't happen.

To test, edit a story to use SAMPLE_WAYPOINTS.slice(0, 5) and switch to linear mode.

Reported here: https://github.com/OpenRailAssociation/osrd/pull/11484#discussion_r2050222687