### PR TITLE
ui-charts: fix spacetimechart crashing when width goes to 0

### DIFF
--- a/ui-charts/src/spaceTimeChart/hooks/useCanvas.ts
+++ b/ui-charts/src/spaceTimeChart/hooks/useCanvas.ts
@@ -241,8 +241,8 @@ export function useCanvas(
 
         canvas.style.width = size.width + 'px';
         canvas.style.height = size.height + 'px';
-        canvas.setAttribute('width', size.width * ratio + 'px');
-        canvas.setAttribute('height', size.height * ratio + 'px');
+        canvas.setAttribute('width', Math.max(1, size.width * ratio) + 'px');
+        canvas.setAttribute('height', Math.max(1, size.height * ratio) + 'px');
 
         if (!isPicking) {
           // Reset the transform to identity, then apply the new scale


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/11385

The issue occurs when the width naturally goes to 1 due to the width of the page being too small, but with a ratio lower than 1, leading to an invalid value for the final width of the canvas. (Perhaps instead we could stop rendering the component entirely in such a case? It's not a very relevant case though.)